### PR TITLE
Add additional support for multiple libraries of same collection type

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/PluginConfiguration.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/PluginConfiguration.cs
@@ -12,6 +12,10 @@ namespace Jellyfin.Plugin.HomeScreenSections.Configuration
 
         public string? LibreTranslateApiKey { get; set; } = "";
         
+        public string? DefaultMoviesLibraryId { get; set; } = "";
+        
+        public string? DefaultTVShowsLibraryId { get; set; } = "";
+        
         public SectionSettings[] SectionSettings { get; set; } = Array.Empty<SectionSettings>();
     }
 

--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
@@ -49,6 +49,20 @@
                     <input is="emby-input" type="text" data-id="txtLibreTranslateApiKey" required="required" label="LibreTranslate API Key" />
                     <span>API Key for LibreTranslate instance.</span>
                 </div>
+                <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="defaultMoviesLibrary">Default Movies Library</label>
+                    <select is="emby-select" id="defaultMoviesLibrary" class="emby-select-withcolor emby-select">
+                        <option value="">Default</option>
+                    </select>
+                    <div class="fieldDescription">Select the specific movies library to use for navigation. Lists all underlying library folders (not grouped views). <strong>Requires Jellyfin restart to take effect.</strong></div>
+                </div>
+                <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="defaultTVShowsLibrary">Default TV Shows Library</label>
+                    <select is="emby-select" id="defaultTVShowsLibrary" class="emby-select-withcolor emby-select">
+                        <option value="">Default</option>
+                    </select>
+                    <div class="fieldDescription">Select the specific TV shows library to use for navigation. Lists all underlying library folders (not grouped views). <strong>Requires Jellyfin restart to take effect.</strong></div>
+                </div>
             </fieldset>
             <fieldset class="verticalSection-extrabottompadding">
                 <legend>Section Settings</legend>
@@ -128,6 +142,50 @@
                 btnSave: document.querySelector('#btnSaveConfig'),
                 init: function () {
                     HomeScreenSections.loadConfig();
+                    HomeScreenSections.loadLibraries();
+                },
+                loadLibraries: function () {
+                    // Use getVirtualFolders instead of getUserViews to get actual library folders
+                    window.ApiClient.getVirtualFolders().then(function (result) {
+                        const moviesSelect = document.querySelector('#defaultMoviesLibrary');
+                        const tvShowsSelect = document.querySelector('#defaultTVShowsLibrary');
+                        
+                        // Clear existing options except the first one
+                        moviesSelect.innerHTML = '<option value="">Default</option>';
+                        tvShowsSelect.innerHTML = '<option value="">Default</option>';
+                        
+                        // Add movie libraries
+                        result.filter(folder => folder.CollectionType === 'movies').forEach(function (folder) {
+                            const option = document.createElement('option');
+                            
+                            // Ensure the ID is in proper GUID format with hyphens
+                            let folderId = folder.ItemId;
+                            if (folderId && !folderId.includes('-')) {
+                                // Format as GUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+                                folderId = folderId.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5');
+                            }
+                            option.value = folderId;
+                            option.textContent = folder.Name;
+                            moviesSelect.appendChild(option);
+                        });
+                        
+                        // Add TV show libraries
+                        result.filter(folder => folder.CollectionType === 'tvshows').forEach(function (folder) {
+                            const option = document.createElement('option');
+                            
+                            // Ensure the ID is in proper GUID format with hyphens
+                            let folderId = folder.ItemId;
+                            if (folderId && !folderId.includes('-')) {
+                                // Format as GUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+                                folderId = folderId.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5');
+                            }
+                            option.value = folderId;
+                            option.textContent = folder.Name;
+                            tvShowsSelect.appendChild(option);
+                        });
+                    }).catch(function (error) {
+                        console.error('Failed to load libraries:', error);
+                    });
                 },
                 saveConfig: function (e) {
                     e.preventDefault();
@@ -137,6 +195,8 @@
                         AllowUserOverride: document.querySelector('#globalAllowUserOverride').checked,
                         LibreTranslateUrl: document.querySelector('[data-id=txtLibreTranslateUrl]').value,
                         LibreTranslateApiKey: document.querySelector('[data-id=txtLibreTranslateApiKey]').value,
+                        DefaultMoviesLibraryId: document.querySelector('#defaultMoviesLibrary').value,
+                        DefaultTVShowsLibraryId: document.querySelector('#defaultTVShowsLibrary').value,
                         SectionSettings: []
                     };
                     
@@ -172,6 +232,16 @@
                             document.querySelector('#globalAllowUserOverride').checked = config.AllowUserOverride;
                             document.querySelector('[data-id=txtLibreTranslateUrl]').value = config.LibreTranslateUrl;
                             document.querySelector('[data-id=txtLibreTranslateApiKey]').value = config.LibreTranslateApiKey;
+                            
+                            // Set library dropdown values after libraries are loaded
+                            setTimeout(function() {
+                                if (config.DefaultMoviesLibraryId) {
+                                    document.querySelector('#defaultMoviesLibrary').value = config.DefaultMoviesLibraryId;
+                                }
+                                if (config.DefaultTVShowsLibraryId) {
+                                    document.querySelector('#defaultTVShowsLibrary').value = config.DefaultTVShowsLibraryId;
+                                }
+                            }, 500); // Small delay to ensure libraries are loaded
                             
                             // Get plugin defaults for each section it defines
                             // Loop over these sections and add in what the config has overwritten
@@ -211,7 +281,7 @@
                                 LowerLimit: 1,
                                 UpperLimit: sectionTypes[i].Limit,
                                 ViewMode: sectionTypes[i].ViewMode,
-                                OrderIndex: 999 // new sections will always appear last to avoid admins orders being screwed
+                                OrderIndex: 999 // new sections appear last
                             };
                             
                             HomeScreenSections.addSectionSetting(newConfig, sectionTypes[i]);

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/LatestMoviesSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/LatestMoviesSection.cs
@@ -21,7 +21,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
         
         public int? Limit => 1;
 
-        public string? Route { get; set; } = null;
+        public string? Route => "movies";
         
         public string? AdditionalData { get; set; }
         
@@ -64,32 +64,54 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
             
             User? user = m_userManager.GetUserById(payload.UserId);
 
-            Folder? movieFolder = m_libraryManager.GetUserRootFolder()
-                .GetChildren(user, true)
-                .OfType<Folder>()
-                .FirstOrDefault(x => (x as ICollectionFolder)?.CollectionType == CollectionType.movies);
-
-            QueryResult<BaseItem>? latestMovies = movieFolder?.GetItems(new InternalItemsQuery
+            List<BaseItem> latestMovies = m_libraryManager.GetItemList(new InternalItemsQuery(user)
             {
-                IncludeItemTypes = new[]
-                {
-                    BaseItemKind.Movie
-                },
+                IncludeItemTypes = new[] { BaseItemKind.Movie },
                 Limit = 16,
-                User = user,
-                OrderBy = new[]
-                {
-                    (ItemSortBy.PremiereDate, SortOrder.Descending)
-                }
+                OrderBy = new[] { (ItemSortBy.PremiereDate, SortOrder.Descending) }
             });
 
-            return new QueryResult<BaseItemDto>(Array.ConvertAll(latestMovies?.Items.ToArray() ?? Array.Empty<BaseItem>(),
+            return new QueryResult<BaseItemDto>(Array.ConvertAll(latestMovies.ToArray(),
                 i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)));
         }
 
         public IHomeScreenSection CreateInstance(Guid? userId, IEnumerable<IHomeScreenSection>? otherInstances = null)
         {
-            return this;
+            User? user = m_userManager.GetUserById(userId ?? Guid.Empty);
+
+            BaseItemDto? originalPayload = null;
+            
+            // Get only movie collection folders that the user can access
+            var movieFolders = m_libraryManager.GetUserRootFolder()
+                .GetChildren(user, true)
+                .OfType<Folder>()
+                .Where(x => (x as ICollectionFolder)?.CollectionType == CollectionType.movies)
+                .ToArray();
+            
+            // Check if there's a configured default library, otherwise use first available
+            var config = HomeScreenSectionsPlugin.Instance?.Configuration;
+            var selectedLibrary = !string.IsNullOrEmpty(config?.DefaultMoviesLibraryId)
+                ? movieFolders.FirstOrDefault(x => x.Id.ToString() == config.DefaultMoviesLibraryId)
+                : null;
+            
+            // Fall back to first movies library if no configured library found
+            selectedLibrary ??= movieFolders.FirstOrDefault();
+            
+            if (selectedLibrary != null)
+            {
+                DtoOptions dtoOptions = new DtoOptions();
+                dtoOptions.Fields =
+                    [..dtoOptions.Fields, ItemFields.PrimaryImageAspectRatio, ItemFields.DisplayPreferencesId];
+                
+                originalPayload = Array.ConvertAll(new[] { selectedLibrary }, i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)).First();
+            }
+
+            return new LatestMoviesSection(m_userViewManager, m_userManager, m_libraryManager, m_dtoService)
+            {
+                DisplayText = DisplayText,
+                AdditionalData = AdditionalData,
+                OriginalPayload = originalPayload
+            };
         }
         
         public HomeScreenSectionInfo GetInfo()

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/LatestShowsSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/LatestShowsSection.cs
@@ -23,11 +23,11 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
         
         public int? Limit => 1;
         
-        public string? Route { get; }
+        public string? Route => "tvshows";
         
         public string? AdditionalData { get; set; }
         
-        public object? OriginalPayload { get; }
+        public object? OriginalPayload { get; set; } = null;
         
         private readonly IUserViewManager m_userViewManager;
         private readonly IUserManager m_userManager;
@@ -74,7 +74,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
                 IncludeItemTypes = new[] { BaseItemKind.Episode },
                 OrderBy = new[] { (ItemSortBy.PremiereDate, SortOrder.Descending) },
                 DtoOptions = new DtoOptions
-                    { Fields = new[] { ItemFields.SeriesPresentationUniqueKey }, EnableImages = false }
+                    { Fields = new[] { ItemFields.SeriesPresentationUniqueKey }, EnableImages = true }
             });
             
             List<BaseItem> series = episodes
@@ -93,7 +93,41 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
 
         public IHomeScreenSection CreateInstance(Guid? userId, IEnumerable<IHomeScreenSection>? otherInstances = null)
         {
-            return this;
+            User? user = m_userManager.GetUserById(userId ?? Guid.Empty);
+
+            BaseItemDto? originalPayload = null;
+            
+            // Get only TV show collection folders that the user can access
+            var tvShowFolders = m_libraryManager.GetUserRootFolder()
+                .GetChildren(user, true)
+                .OfType<Folder>()
+                .Where(x => (x as ICollectionFolder)?.CollectionType == CollectionType.tvshows)
+                .ToArray();
+            
+            // Check if there's a configured default library, otherwise use first available
+            var config = HomeScreenSectionsPlugin.Instance?.Configuration;
+            var selectedLibrary = !string.IsNullOrEmpty(config?.DefaultTVShowsLibraryId)
+                ? tvShowFolders.FirstOrDefault(x => x.Id.ToString() == config.DefaultTVShowsLibraryId)
+                : null;
+            
+            // Fall back to first TV shows library if no configured library found
+            selectedLibrary ??= tvShowFolders.FirstOrDefault();
+            
+            if (selectedLibrary != null)
+            {
+                DtoOptions dtoOptions = new DtoOptions();
+                dtoOptions.Fields =
+                    [..dtoOptions.Fields, ItemFields.PrimaryImageAspectRatio, ItemFields.DisplayPreferencesId];
+                
+                originalPayload = Array.ConvertAll(new[] { selectedLibrary }, i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)).First();
+            }
+
+            return new LatestShowsSection(m_userViewManager, m_userManager, m_libraryManager, m_tvSeriesManager, m_dtoService)
+            {
+                DisplayText = DisplayText,
+                AdditionalData = AdditionalData,
+                OriginalPayload = originalPayload
+            };
         }
         
         public HomeScreenSectionInfo GetInfo()

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/RecentlyAddedShowsSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/RecentlyAddedShowsSection.cs
@@ -108,21 +108,31 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
         {
             User? user = m_userManager.GetUserById(userId ?? Guid.Empty);
 
-            Folder? folder = m_libraryManager.GetUserRootFolder()
+            BaseItemDto? originalPayload = null;
+            
+            // Get only TV show collection folders that the user can access
+            var tvShowFolders = m_libraryManager.GetUserRootFolder()
                 .GetChildren(user, true)
                 .OfType<Folder>()
-                .Select(x => x as ICollectionFolder)
-                .Where(x => x != null)
-                .FirstOrDefault(x => x!.CollectionType == CollectionType.tvshows) as Folder;
-
-            BaseItemDto? originalPayload = null;
-            if (folder != null)
+                .Where(x => (x as ICollectionFolder)?.CollectionType == CollectionType.tvshows)
+                .ToArray();
+            
+            // Check if there's a configured default library, otherwise use first available
+            var config = HomeScreenSectionsPlugin.Instance?.Configuration;
+            var selectedLibrary = !string.IsNullOrEmpty(config?.DefaultTVShowsLibraryId)
+                ? tvShowFolders.FirstOrDefault(x => x.Id.ToString() == config.DefaultTVShowsLibraryId)
+                : null;
+            
+            // Fall back to first TV shows library if no configured library found
+            selectedLibrary ??= tvShowFolders.FirstOrDefault();
+            
+            if (selectedLibrary != null)
             {
                 DtoOptions dtoOptions = new DtoOptions();
                 dtoOptions.Fields =
                     [..dtoOptions.Fields, ItemFields.PrimaryImageAspectRatio, ItemFields.DisplayPreferencesId];
-
-                originalPayload = Array.ConvertAll(new[] { folder }, i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)).First();
+                
+                originalPayload = Array.ConvertAll(new[] { selectedLibrary }, i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)).First();
             }
 
             return new RecentlyAddedShowsSection(m_userViewManager, m_userManager, m_libraryManager, m_dtoService)


### PR DESCRIPTION
# Add support for multiple libraries of same collection type

I have some potential improvements for multiple libraries of the same collection type, such as in the case of "4K Movies" and "Movies" libraries. In that case the "4K Movies" library may end up being used as the default library causing the "Latest Movies" section to only display results for "4K Movies" and the clickable "Recently Added" header to link to "4K Movies".

- Latest Movies now aggregates content from all movie libraries, similar to Recently Added behavior. (Previously only showed the default library)
- Made Latest Movies and Shows section headers clickable for navigation
- Previous header link behavior used default library selection (likely alphabetical). Added admin configuration to set specific default libraries. Users without access to the configured default will automatically use the first available library of that collection type.

## Changes

### Multi-Library Content Support
- Updated content queries to aggregate across all libraries of the correct type
- Latest sections now show content from all accessible movie/TV libraries

### Configurable Default Libraries  
- Added `DefaultMoviesLibraryId` and `DefaultTVShowsLibraryId` configuration options
- Admin UI dropdowns automatically populate with libraries filtered by CollectionType
- Fallback to the first library of that collectiontype when configured library is unavailable, such as no permissions

### Added Header Link Navigation to "Latest" sections
- Links to the respective default library. However, not sorted by premiere date.

Please let me know if you would prefer I split this PR into separate changes for a partial merge.