### PR TITLE
Plugin custom configuration system and granular admin override controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,87 @@ Send an HTTP POST request to `http(s)://{YOUR_JELLYFIN_URL}/HomeScreen/RegisterS
 	"displayText":"", // What text should be displayed for your section
 	"limit": 1, // This can only be 1 at the moment, I am working hard to support more than 1 section via HTTP request 
 	"additionalData": "", // Any accompanying data you want sent to your endpoint
-	"resultsEndpoint":"" // The endpoint that will be requested when the section is requested. Expected to return `QueryResult<BaseItemDto>`
+	"resultsEndpoint":"", // The endpoint that will be requested when the section is requested. Expected to return `QueryResult<BaseItemDto>`
+	"configurationOptions": [ // (Optional) Plugin-specific configuration options
+		{
+			"Key": "ShowEmpty", // Unique key for this configuration option
+			"Name": "Show When Empty", // Display name for admins/users
+			"Description": "Display this section even when no items are available", // Help text
+			"Type": "Checkbox", // Boolean configuration
+			"AllowUserOverride": true, // Whether users can override this setting
+			"DefaultValue": false, // Default value for this option
+			"IsAdvanced": false // Whether this appears in advanced options only
+		},
+		{
+			"Key": "SortOrder",
+			"Name": "Sort Order",
+			"Description": "How items should be sorted in this section",
+			"Type": "Dropdown", // Selection from predefined options
+			"AllowUserOverride": true,
+			"DefaultValue": "DateCreated",
+			"DropdownOptions": ["DateCreated", "PremiereDate", "SortName", "Random"],
+			"DropdownLabels": ["Date Added", "Release Date", "Alphabetical", "Random"],
+			"IsAdvanced": false
+		},
+		{
+			"Key": "ApiKey",
+			"Name": "API Key", 
+			"Description": "Your secret API key for external service integration",
+			"Type": "TextBox", // Text input with validation
+			"AllowUserOverride": false,
+			"DefaultValue": "",
+			"Placeholder": "Enter your API key...",
+			"MinLength": 16,
+			"MaxLength": 64,
+			"Pattern": "^[A-Za-z0-9_-]+$",
+			"IsAdvanced": true
+		},
+		{
+			"Key": "ItemLimit",
+			"Name": "Item Limit",
+			"Description": "Maximum number of items to display",
+			"Type": "NumberBox", // Numeric input with validation
+			"AllowUserOverride": true,
+			"DefaultValue": 16,
+			"MinValue": 1,
+			"MaxValue": 50,
+			"Step": 1,
+			"IsAdvanced": false
+		}
+	]
 }
 ```
+
+<details>
+<summary><strong>Configuration Option Properties</strong></summary>
+
+Each configuration option supports the following properties:
+
+**Core Properties:**
+- `Key` (string): Unique identifier
+- `Name` (string): Display name
+- `Description` (string): Help text
+- `Type` (string): "Checkbox", "Dropdown", "TextBox", or "NumberBox"
+- `DefaultValue` (varies): Default value
+- `AllowUserOverride` (boolean): Whether users can override this setting
+- `IsAdvanced` (boolean): Whether this option appears only in advanced
+
+**Text Input Properties (TextBox type):**
+- `Placeholder` (string): Placeholder text for the input field
+- `MinLength` (integer): Minimum required text length
+- `MaxLength` (integer): Maximum allowed text length  
+- `Pattern` (string): Regex pattern for validation
+
+**Numeric Input Properties (NumberBox type):**
+- `MinValue` (number): Minimum value
+- `MaxValue` (number): Maximum value
+- `Step` (number): Increment step size
+
+**Dropdown Properties (Dropdown type):**
+- `DropdownOptions` (array): Array of option values
+- `DropdownLabels` (array): Array of display labels
+
+</details>
 
 ### Pull Requests
 I'm open to any and all pull requests that expand the functionality of this plugin, while keeping within the scope of what its outlined to do, however if the PR includes new sections which **are not** vanilla implementations it will be rejected as the above approach is preferred.

--- a/src/Jellyfin.Plugin.HomeScreenSections/Config/settings.html
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Config/settings.html
@@ -1,4 +1,38 @@
 <form id="config-page" class="configForm" style="margin: 0 auto;">
+    <style>
+        .admin-managed-note {
+            color: var(--theme-text-color-secondary);
+            font-style: italic;
+            font-size: 0.9em;
+            margin-top: 0.25em;
+        }
+        
+        .fieldDescription {
+            color: var(--theme-text-color-secondary);
+            font-size: 0.85em;
+            margin-top: 0.25em;
+        }
+        
+
+        input[disabled] ~ span .checkboxIcon,
+        input:disabled ~ span .checkboxIcon {
+            background-color: rgba(0,0,0,.5) !important;
+            color: rgba(255,255,255,.4) !important;
+        }
+        
+        .advanced-options {
+            display: none;
+        }
+        
+        .advanced-options.show {
+            display: block;
+        }
+        
+        .advanced-toggle {
+            margin: 1em 0;
+        }
+    </style>
+    
     <div class="verticalSection verticalSection-extrabottompadding">
         <h2 class="sectionTitle">Modular Home  - Settings:</h2>
 
@@ -10,8 +44,8 @@
         </div>
 
         <div class="verticalSection verticalSection-extrabottompadding">
-            <h3>Enabled Sections</h3>
-            <div id="enabledSections">
+            <h3>Section Settings</h3>
+            <div id="sectionSettings">
             </div>
         </div>
 
@@ -24,11 +58,68 @@
 
     const config = {
         setup: function () {
-            ApiClient.getDisplayPreferences('usersettings', ApiClient.getCurrentUserId(), 'emby').then(function (userSettings) {
-                document.querySelector('#modularHomeEnabled').checked = userSettings.CustomPrefs['useModularHome'] === 'true';
+            if (typeof ApiClient === 'undefined') {
+                Dashboard.alert('Plugin settings are not available in this context. Please access them through the admin dashboard.');
+                return;
+            }
+            
+            if (typeof Dashboard !== 'undefined' && Dashboard.showLoadingMsg) {
+                Dashboard.showLoadingMsg();
+            }
+            
+            // Check plugin configuration to determine checkbox state and behavior
+            ApiClient.fetch({
+                url: ApiClient.getUrl('HomeScreen/Configuration'),
+                type: 'GET',
+                dataType: 'json',
+                headers: {
+                    accept: 'application/json'
+                }
+            }).then(function (pluginConfig) {
+                if (pluginConfig.AllowUserOverride === true) {
+                    // User override allowed - show user's personal preference
+                    ApiClient.getDisplayPreferences('usersettings', ApiClient.getCurrentUserId(), 'emby').then(function (userSettings) {
+                        document.querySelector('#modularHomeEnabled').checked = userSettings.CustomPrefs['useModularHome'] === 'true';
+                        document.querySelector('#modularHomeEnabled').disabled = false;
+                        addAdvancedToggleAfterNote();
+                    }).catch(function(error) {
+                        document.querySelector('#modularHomeEnabled').checked = false;
+                        document.querySelector('#modularHomeEnabled').disabled = false;
+                        addAdvancedToggleAfterNote();
+                    });
+                } else {
+                    document.querySelector('#modularHomeEnabled').checked = pluginConfig.Enabled === true;
+                    document.querySelector('#modularHomeEnabled').disabled = true;
+                    
+                    const existingNote = document.querySelector('#modularHomeEnabled').closest('.verticalSection').querySelector('.admin-managed-note');
+                    if (!existingNote) {
+                        const noteElement = document.createElement('div');
+                        noteElement.className = 'admin-managed-note';
+                        noteElement.textContent = 'This setting is managed by the administrator.';
+                        document.querySelector('#modularHomeEnabled').closest('.verticalSection').appendChild(noteElement);
+                    }
+                    addAdvancedToggleAfterNote();
+                }
+            }).catch(function(error) {
+                const errorMessage = error && error.message ? error.message : 'Unable to load plugin configuration.';
+                
+                document.querySelector('#modularHomeEnabled').checked = false;
+                document.querySelector('#modularHomeEnabled').disabled = true;
+                
+                const existingNote = document.querySelector('#modularHomeEnabled').closest('.verticalSection').querySelector('.admin-managed-note');
+                if (!existingNote) {
+                    const noteElement = document.createElement('div');
+                    noteElement.className = 'admin-managed-note';
+                    noteElement.textContent = errorMessage;
+                    document.querySelector('#modularHomeEnabled').closest('.verticalSection').appendChild(noteElement);
+                }
+                
+                addAdvancedToggleAfterNote();
+                
+                if (typeof Dashboard !== 'undefined' && Dashboard.hideLoadingMsg) {
+                    Dashboard.hideLoadingMsg();
+                }
             });
-
-            let urlStart = window.location.protocol + '//' + window.location.host;
 
             ApiClient.fetch({
                 url: ApiClient.getUrl('ModularHomeViews/UserSettings?userId=' + ApiClient.getCurrentUserId()),
@@ -38,57 +129,344 @@
                     accept: 'application/json'
                 }
             }).then(function (settings) {
+                // Get user override permissions instead of full plugin configuration
                 ApiClient.fetch({
-                    url: ApiClient.getUrl('ModularHomeViews/Sections'),
+                    url: ApiClient.getUrl('ModularHomeViews/UserOverridePermissions'),
                     type: 'GET',
                     dataType: 'json',
                     headers: {
                         accept: 'application/json'
                     }
-                }).then(function (response) {
-                    if (response.TotalRecordCount > 0) {
+                }).then(function (userOverridePermissions) {
+                    ApiClient.fetch({
+                        url: ApiClient.getUrl('ModularHomeViews/Sections'),
+                        type: 'GET',
+                        dataType: 'json',
+                        headers: {
+                            accept: 'application/json'
+                        }
+                    }).then(function (response) {
+                        if (response.TotalRecordCount > 0) {
 
-                        let html = '';
-                        for (let i = 0; i < response.TotalRecordCount; ++i) {
-                            let section = response.Items[i];
+                            let html = '';
+                            for (let i = 0; i < response.TotalRecordCount; ++i) {
+                                let section = response.Items[i];
 
-                            let checked = false;
-                            if (settings.EnabledSections.includes(section.Section)) {
-                                checked = true;
+                                // Find existing settings for this section or create defaults
+                                let sectionSettings = settings.SectionSettings.find(s => s.SectionId === section.Section);
+                                if (!sectionSettings) {
+                                    sectionSettings = {
+                                        SectionId: section.Section,
+                                        Enabled: settings.EnabledSections.includes(section.Section),
+                                        ShowPlayedItems: true,
+                                        PreventDuplicates: true,
+                                        CustomDisplayName: null
+                                    };
+                                    settings.SectionSettings.push(sectionSettings);
+                                }
+
+                                // Get user override permissions for this section
+                                let sectionPermissions = userOverridePermissions[section.Section] || {};
+                                let sectionVisible = sectionPermissions['SectionVisible'] !== false;
+                                let allowUserOverride = sectionPermissions['EnableDisableSection'] !== false;
+                                let customDisplayNameAllowed = sectionPermissions['CustomDisplayName'] !== false;
+
+                                // Skip sections that are not visible to users
+                                if (!sectionVisible) {
+                                    continue;
+                                }
+
+                                html += '<h3 class="checkboxListLabel">' + section.DisplayText + '</h3>';
+                                html += '<div class="checkboxList paperList checkboxList-paperList">';
+                                
+                                // Enabled checkbox - show for all visible sections, but disable if user override not allowed
+                                html += '<label class="listItemCheckboxContainer">';
+                                html += '<input is="emby-checkbox" type="checkbox" class="sectionEnabledCheckbox user-section-enabled-checkbox" data-section="' + section.Section + '" ' + (sectionSettings.Enabled ? 'checked' : '') + ' ' + (!allowUserOverride ? 'disabled' : '') + ' />';
+                                html += '<span>Enable this section</span>';
+                                html += '</label>';
+                                if (!allowUserOverride) {
+                                    html += '<div class="admin-managed-note">This section is managed by the administrator.</div>';
+                                }
+                                
+                                // Custom display name input (only if allowed by admin) - moved to be right after enable/disable
+                                if (customDisplayNameAllowed) {
+                                    html += '<div class="inputContainer advanced-options">';
+                                    html += '<label class="inputLabel inputLabelUnfocused">Custom Display Name</label>';
+                                    html += '<input type="text" is="emby-input" class="sectionCustomDisplayName" data-section="' + section.Section + '" value="' + (sectionSettings.CustomDisplayName || '') + '" placeholder="Leave blank for default" ' + (!allowUserOverride ? 'disabled' : '') + '>';
+                                    html += '<div class="fieldDescription">Override the display name for this section.</div>';
+                                    html += '</div>';
+                                }
+                                
+                                // Dynamic configuration options placeholder
+                                html += '<div class="dynamic-config-container" data-section="' + section.Section + '"></div>';
+
+                                html += '</div>'; // Close checkboxList
                             }
 
-                            html += '<label class="checkboxContainer">';
-                            html += '<input is="emby-checkbox" type="checkbox" class="sectionEnabledCheckbox" data-section="' + section.Section + '" ' + (checked ? 'checked' : '') + ' />';
-                            html += '<span>' + section.DisplayText + '</span>';
-                            html += '</label>';
+                            let elem = document.querySelector('#sectionSettings');
+                            elem.innerHTML = html;
+                            
+                            // Populate dynamic configuration options for each section
+                            response.Items.forEach(function(section) {
+                                // Get section-specific permissions for this section
+                                const sectionPermissions = userOverridePermissions[section.Section] || {};
+                                const sectionAllowUserOverride = sectionPermissions['EnableDisableSection'] !== false;
+                                populateDynamicConfigOptions(section, settings, userOverridePermissions, sectionAllowUserOverride);
+                            });
+                            
+                            if (typeof Dashboard !== 'undefined' && Dashboard.hideLoadingMsg) {
+                                Dashboard.hideLoadingMsg();
+                            }
+                        } else {
+                            if (typeof Dashboard !== 'undefined' && Dashboard.hideLoadingMsg) {
+                                Dashboard.hideLoadingMsg();
+                            }
                         }
-
-                        let elem = document.querySelector('#enabledSections');
-                        elem.innerHTML = html;
+                    }).catch(function(error) {
+                        if (typeof Dashboard !== 'undefined' && Dashboard.hideLoadingMsg) {
+                            Dashboard.hideLoadingMsg();
+                        }
+                    });
+                }).catch(function(error) {
+                    if (typeof Dashboard !== 'undefined' && Dashboard.hideLoadingMsg) {
+                        Dashboard.hideLoadingMsg();
                     }
                 });
+            }).catch(function(error) {
+                if (typeof Dashboard !== 'undefined' && Dashboard.hideLoadingMsg) {
+                    Dashboard.hideLoadingMsg();
+                }
             });
+
+            function addAdvancedToggleAfterNote() {
+                const modularHomeSection = document.querySelector('#modularHomeEnabled').closest('.verticalSection');
+                const existingToggle = modularHomeSection.querySelector('.advanced-toggle');
+                
+                if (!existingToggle) {
+                    const toggleDiv = document.createElement('div');
+                    toggleDiv.className = 'advanced-toggle';
+                    toggleDiv.innerHTML = '<label class="checkboxContainer"><input is="emby-checkbox" type="checkbox" id="showAdvancedOptions" /><span>Show Advanced Options</span></label>';
+                    modularHomeSection.appendChild(toggleDiv);
+                    setupAdvancedToggle();
+                }
+            }
+
+            function setupAdvancedToggle() {
+                const advancedToggle = document.getElementById('showAdvancedOptions');
+                if (advancedToggle) {
+                    const savedState = localStorage.getItem('homeScreenSections.userSettings.showAdvanced');
+                    if (savedState === 'true') {
+                        advancedToggle.checked = true;
+                        const advancedOptions = document.querySelectorAll('.advanced-options');
+                        advancedOptions.forEach(function(element) {
+                            element.style.display = 'block';
+                        });
+                    }
+                    
+                    advancedToggle.addEventListener('change', function() {
+                        const advancedOptions = document.querySelectorAll('.advanced-options');
+                        if (this.checked) {
+                            advancedOptions.forEach(function(element) {
+                                element.style.display = 'block';
+                            });
+                            localStorage.setItem('homeScreenSections.userSettings.showAdvanced', 'true');
+                        } else {
+                            advancedOptions.forEach(function(element) {
+                                element.style.display = 'none';
+                            });
+                            localStorage.setItem('homeScreenSections.userSettings.showAdvanced', 'false');
+                        }
+                    });
+                }
+            }
+
+            async function populateDynamicConfigOptions(section, settings, userOverridePermissions, allowUserOverride) {
+                try {
+                    const url = ApiClient.getUrl(`HomeScreen/Section/${section.Section}/ConfigurationOptions`);
+                    const response = await fetch(url);
+                    
+                    if (!response.ok) {
+                        const container = document.querySelector(`.dynamic-config-container[data-section="${section.Section}"]`);
+                        if (container) {
+                            container.innerHTML = '<div class="admin-managed-note">Unable to load configuration options for this section.</div>';
+                        }
+                        return;
+                    }
+                    
+                    const responseText = await response.text();
+                    let configOptions;
+                    try {
+                        configOptions = JSON.parse(responseText);
+                    } catch (e) {
+                        return;
+                    }
+                    const container = document.querySelector(`.dynamic-config-container[data-section="${section.Section}"]`);
+                    
+                    if (!container || configOptions.length === 0) {
+                        return;
+                    }
+                    
+                    let sectionSettings = settings.SectionSettings.find(s => s.SectionId === section.Section);
+                    if (!sectionSettings) {
+                        sectionSettings = { SectionId: section.Section, PluginConfigurations: {} };
+                    }
+                    if (!sectionSettings.PluginConfigurations) {
+                        sectionSettings.PluginConfigurations = {};
+                    }
+                    
+                    let html = '';
+                    configOptions.forEach(option => {
+                        const canOverride = option.AllowUserOverride !== false;
+                        const currentValue = sectionSettings.PluginConfigurations[option.Key] ?? option.DefaultValue;
+                        const isDisabled = !allowUserOverride || !canOverride;
+                        const isAdvanced = option.IsAdvanced === true;
+                        const advancedClass = isAdvanced ? ' advanced-options' : '';
+                        
+                        let stringValue = '';
+                        if (currentValue !== null && currentValue !== undefined) {
+                            if (typeof currentValue === 'string') {
+                                stringValue = currentValue;
+                            } else if (typeof currentValue === 'number' || typeof currentValue === 'boolean') {
+                                stringValue = String(currentValue);
+                            } else {
+                                stringValue = '';
+                            }
+                        }
+                        
+                        switch (option.Type) {
+                            case 'Checkbox':
+                                html += '<label class="listItemCheckboxContainer' + advancedClass + '">';
+                                html += '<input is="emby-checkbox" type="checkbox" class="pluginConfigCheckbox" data-section="' + section.Section + '" data-config-key="' + option.Key + '" ' + (currentValue ? 'checked' : '') + ' ' + (isDisabled ? 'disabled' : '') + ' />';
+                                html += '<span>' + option.Name + '</span>';
+                                html += '</label>';
+                                if (option.Description) {
+                                    html += '<div class="fieldDescription' + advancedClass + '">' + option.Description + '</div>';
+                                }
+                                break;
+                                
+                            case 'Dropdown':
+                                html += '<div class="selectContainer' + advancedClass + '">';
+                                html += '<label class="inputLabel inputLabelUnfocused">' + option.Name + '</label>';
+                                html += '<select is="emby-select" class="pluginConfigDropdown emby-select-withcolor emby-select" data-section="' + section.Section + '" data-config-key="' + option.Key + '" ' + (isDisabled ? 'disabled' : '') + '>';
+                                if (option.DropdownOptions && option.DropdownLabels) {
+                                    for (let i = 0; i < option.DropdownOptions.length; i++) {
+                                        const selected = option.DropdownOptions[i] === currentValue ? 'selected' : '';
+                                        const label = option.DropdownLabels[i] || option.DropdownOptions[i];
+                                        html += '<option value="' + option.DropdownOptions[i] + '" ' + selected + '>' + label + '</option>';
+                                    }
+                                }
+                                html += '</select>';
+                                if (option.Description) {
+                                    html += '<div class="fieldDescription">' + option.Description + '</div>';
+                                }
+                                html += '</div>';
+                                break;
+                                
+                            case 'TextBox':
+                                html += '<div class="inputContainer' + advancedClass + '">';
+                                html += '<label class="inputLabel inputLabelUnfocused">' + option.Name + '</label>';
+                                html += '<input type="text" is="emby-input" class="pluginConfigTextbox emby-input" data-section="' + section.Section + '" data-config-key="' + option.Key + '" value="' + stringValue + '" ' + (option.ValidationPattern ? ('pattern="' + option.ValidationPattern + '"') : '') + ' ' + (isDisabled ? 'disabled' : '') + '>';
+                                if (option.Description) {
+                                    html += '<div class="fieldDescription">' + option.Description + '</div>';
+                                }
+                                html += '</div>';
+                                break;
+                                
+                            case 'NumberBox':
+                                html += '<div class="inputContainer' + advancedClass + '">';
+                                html += '<label class="inputLabel inputLabelUnfocused">' + option.Name + '</label>';
+                                html += '<input type="number" is="emby-input" class="pluginConfigNumber emby-input" data-section="' + section.Section + '" data-config-key="' + option.Key + '" value="' + (currentValue || option.DefaultValue || '') + '" ' + (option.MinValue !== undefined ? ('min="' + option.MinValue + '"') : '') + ' ' + (option.MaxValue !== undefined ? ('max="' + option.MaxValue + '"') : '') + ' ' + (isDisabled ? 'disabled' : '') + '>';
+                                if (option.Description) {
+                                    html += '<div class="fieldDescription">' + option.Description + '</div>';
+                                }
+                                html += '</div>';
+                                break;
+                        }
+                    });
+                    
+                    container.innerHTML = html;
+                    
+                } catch (error) {
+                    // Silent error handling
+                }
+            }
 
             document.querySelector('.configForm')
                 .addEventListener('submit', function (e) {
+                    if (typeof ApiClient === 'undefined') {
+                        Dashboard.alert('Settings cannot be saved - ApiClient not available.');
+                        e.preventDefault();
+                        return false;
+                    }
+                    
+                    if (typeof Dashboard !== 'undefined' && Dashboard.showLoadingMsg) {
+                        Dashboard.showLoadingMsg();
+                    }
+                    
                     ApiClient.getDisplayPreferences('usersettings', ApiClient.getCurrentUserId(), 'emby').then(function (userSettings) {
-                        userSettings.CustomPrefs['useModularHome'] = document.querySelector('#modularHomeEnabled').checked ? 'true' : 'false';
+                        const modularHomeCheckbox = document.querySelector('#modularHomeEnabled');
+                        if (modularHomeCheckbox && !modularHomeCheckbox.disabled) {
+                            userSettings.CustomPrefs['useModularHome'] = modularHomeCheckbox.checked ? 'true' : 'false';
+                        }
 
                         ApiClient.updateDisplayPreferences('usersettings', userSettings, ApiClient.getCurrentUserId(), 'emby');
+                    }).catch(function(error) {
+                        // Silent error handling
                     });
 
                     let data = {
                         UserId: ApiClient.getCurrentUserId(),
-                        EnabledSections: []
+                        EnabledSections: [],
+                        SectionSettings: []
                     };
 
                     let checkboxes = document.querySelectorAll('.sectionEnabledCheckbox');
 
                     checkboxes.forEach(function (checkbox) {
                         let sectionId = checkbox.getAttribute('data-section');
+                        
+                        if (!checkbox.disabled) {
+                            let customDisplayNameInput = document.querySelector('.sectionCustomDisplayName[data-section="' + sectionId + '"]');
+                            
+                            let pluginConfigurations = {};
+                            
+                            document.querySelectorAll(`.pluginConfigCheckbox[data-section="${sectionId}"]`).forEach(function(element) {
+                                if (!element.disabled) {
+                                    pluginConfigurations[element.getAttribute('data-config-key')] = element.checked;
+                                }
+                            });
+                            
+                            document.querySelectorAll(`.pluginConfigDropdown[data-section="${sectionId}"]`).forEach(function(element) {
+                                if (!element.disabled) {
+                                    pluginConfigurations[element.getAttribute('data-config-key')] = element.value;
+                                }
+                            });
+                            
+                            document.querySelectorAll(`.pluginConfigTextbox[data-section="${sectionId}"]`).forEach(function(element) {
+                                if (!element.disabled) {
+                                    pluginConfigurations[element.getAttribute('data-config-key')] = element.value || '';
+                                }
+                            });
+                            
+                            document.querySelectorAll(`.pluginConfigNumber[data-section="${sectionId}"]`).forEach(function(element) {
+                                if (!element.disabled) {
+                                    const value = element.value ? parseFloat(element.value) : null;
+                                    pluginConfigurations[element.getAttribute('data-config-key')] = value;
+                                }
+                            });
+                            
+                            let sectionSettings = {
+                                SectionId: sectionId,
+                                Enabled: checkbox.checked,
+                                CustomDisplayName: customDisplayNameInput && !customDisplayNameInput.disabled ? (customDisplayNameInput.value || null) : null,
+                                PluginConfigurations: pluginConfigurations
+                            };
+                            
+                            data.SectionSettings.push(sectionSettings);
 
-                        if (checkbox.checked) {
-                            data.EnabledSections.push(sectionId);
+                            if (checkbox.checked) {
+                                data.EnabledSections.push(sectionId);
+                            }
                         }
                     });
 
@@ -98,12 +476,25 @@
                         data: JSON.stringify(data),
                         contentType: 'application/json'
                     }).then(function () {
+                        if (typeof Dashboard !== 'undefined' && Dashboard.hideLoadingMsg) {
+                            Dashboard.hideLoadingMsg();
+                        }
                         Dashboard.alert('Settings have been updated, reloading page in 2 seconds.');
 
                         setTimeout(function () {
                             location.reload(true);
                         }, 2000);
-                    })
+                    }).catch(function(error) {
+                        if (typeof Dashboard !== 'undefined' && Dashboard.hideLoadingMsg) {
+                            Dashboard.hideLoadingMsg();
+                        }
+                        
+                        if (typeof Dashboard !== 'undefined' && Dashboard.processErrorResponse) {
+                            Dashboard.processErrorResponse(error);
+                        } else {
+                            Dashboard.alert('Error saving settings: ' + (error.message || 'Unknown error occurred'));
+                        }
+                    });
 
                     e.preventDefault();
                     return false;

--- a/src/Jellyfin.Plugin.HomeScreenSections/Config/settings.html
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Config/settings.html
@@ -55,8 +55,11 @@
     </button>
 </form>
 <script defer>
-
-    const config = {
+    // Use a unique namespace to avoid conflicts
+    (function() {
+        'use strict';
+        
+        const homeScreenSectionsConfig = {
         setup: function () {
             if (typeof ApiClient === 'undefined') {
                 Dashboard.alert('Plugin settings are not available in this context. Please access them through the admin dashboard.');
@@ -217,6 +220,11 @@
                             if (typeof Dashboard !== 'undefined' && Dashboard.hideLoadingMsg) {
                                 Dashboard.hideLoadingMsg();
                             }
+
+                            const savedAdvancedState = localStorage.getItem('homeScreenSections.userSettings.showAdvanced');
+                            if (savedAdvancedState === 'true') {
+                                showAdvancedOptions();
+                            }
                         } else {
                             if (typeof Dashboard !== 'undefined' && Dashboard.hideLoadingMsg) {
                                 Dashboard.hideLoadingMsg();
@@ -257,27 +265,33 @@
                     const savedState = localStorage.getItem('homeScreenSections.userSettings.showAdvanced');
                     if (savedState === 'true') {
                         advancedToggle.checked = true;
-                        const advancedOptions = document.querySelectorAll('.advanced-options');
-                        advancedOptions.forEach(function(element) {
-                            element.style.display = 'block';
-                        });
+                        showAdvancedOptions();
                     }
                     
                     advancedToggle.addEventListener('change', function() {
-                        const advancedOptions = document.querySelectorAll('.advanced-options');
                         if (this.checked) {
-                            advancedOptions.forEach(function(element) {
-                                element.style.display = 'block';
-                            });
+                            showAdvancedOptions();
                             localStorage.setItem('homeScreenSections.userSettings.showAdvanced', 'true');
                         } else {
-                            advancedOptions.forEach(function(element) {
-                                element.style.display = 'none';
-                            });
+                            hideAdvancedOptions();
                             localStorage.setItem('homeScreenSections.userSettings.showAdvanced', 'false');
                         }
                     });
                 }
+            }
+
+            function showAdvancedOptions() {
+                const advancedOptions = document.querySelectorAll('.advanced-options');
+                advancedOptions.forEach(function(element) {
+                    element.style.display = 'block';
+                });
+            }
+
+            function hideAdvancedOptions() {
+                const advancedOptions = document.querySelectorAll('.advanced-options');
+                advancedOptions.forEach(function(element) {
+                    element.style.display = 'none';
+                });
             }
 
             async function populateDynamicConfigOptions(section, settings, userOverridePermissions, allowUserOverride) {
@@ -386,6 +400,11 @@
                     
                     container.innerHTML = html;
                     
+                    const savedAdvancedState = localStorage.getItem('homeScreenSections.userSettings.showAdvanced');
+                    if (savedAdvancedState === 'true') {
+                        showAdvancedOptions();
+                    }
+                    
                 } catch (error) {
                     // Silent error handling
                 }
@@ -479,11 +498,11 @@
                         if (typeof Dashboard !== 'undefined' && Dashboard.hideLoadingMsg) {
                             Dashboard.hideLoadingMsg();
                         }
-                        Dashboard.alert('Settings have been updated, reloading page in 2 seconds.');
+                        // Set a flag to trigger refresh
+                        localStorage.setItem('homeScreenSections.refreshNeeded', 'true');
 
-                        setTimeout(function () {
-                            location.reload(true);
-                        }, 2000);
+                        // Injected script will handle the refresh
+                        Dashboard.navigate('#!/home.html');
                     }).catch(function(error) {
                         if (typeof Dashboard !== 'undefined' && Dashboard.hideLoadingMsg) {
                             Dashboard.hideLoadingMsg();
@@ -502,6 +521,7 @@
         }
     }
 
-    config.setup();
+    homeScreenSectionsConfig.setup();
+    })();
 
 </script>

--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/PluginConfiguration.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/PluginConfiguration.cs
@@ -1,4 +1,6 @@
-﻿using MediaBrowser.Model.Plugins;
+﻿using System.Text.Json.Serialization;
+using System.Xml.Serialization;
+using MediaBrowser.Model.Plugins;
 
 namespace Jellyfin.Plugin.HomeScreenSections.Configuration
 {
@@ -8,18 +10,83 @@ namespace Jellyfin.Plugin.HomeScreenSections.Configuration
 
         public bool AllowUserOverride { get; set; } = true;
 
+        public bool RespectUserHomepage { get; set; } = true;
+
         public string? LibreTranslateUrl { get; set; } = "";
 
         public string? LibreTranslateApiKey { get; set; } = "";
         
+        public string? DefaultMoviesLibraryId { get; set; } = "";
+        
+        public string? DefaultTVShowsLibraryId { get; set; } = "";
+        
         public SectionSettings[] SectionSettings { get; set; } = Array.Empty<SectionSettings>();
     }
 
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum SectionViewMode
     {
         Portrait,
         Landscape,
         Square
+    }
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum UserOverrideItem
+    {
+        CustomDisplayName,
+        EnableDisableSection
+    }
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum PluginConfigurationType
+    {
+        Checkbox,
+        Dropdown,
+        TextBox,
+        NumberBox
+    }
+
+    public class PluginConfigurationOption
+    {
+        public string Key { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public PluginConfigurationType Type { get; set; }
+        public bool AllowUserOverride { get; set; } = false;
+        public bool IsAdvanced { get; set; } = false;
+        public object? DefaultValue { get; set; }
+        public string[]? DropdownOptions { get; set; } // For dropdown type
+        public string[]? DropdownLabels { get; set; } // Human-readable labels for dropdown options
+        
+        // Additional properties for text/number validation
+        public string? Placeholder { get; set; } // Placeholder text for text/number inputs
+        public int? MinLength { get; set; } // Minimum length for text inputs
+        public int? MaxLength { get; set; } // Maximum length for text inputs
+        public double? MinValue { get; set; } // Minimum value for number inputs
+        public double? MaxValue { get; set; } // Maximum value for number inputs
+        public double? Step { get; set; } // Step increment for number inputs
+        public string? Pattern { get; set; } // Regex pattern for text validation
+        public string? ValidationMessage { get; set; } // Custom validation error message
+    }
+    
+    public class UserOverrideSetting
+    {
+        public UserOverrideItem Item { get; set; }
+        public bool AllowUserOverride { get; set; } = true;
+    }
+
+    [XmlType("PluginConfigurationEntry")]
+    public class PluginConfigurationEntry
+    {
+        [XmlAttribute("Key")]
+        public string Key { get; set; } = string.Empty;
+        
+        [XmlAttribute("Value")]
+        public string? Value { get; set; }
+        
+        [XmlAttribute("Type")]
+        public string Type { get; set; } = "string";
     }
     
     public class SectionSettings
@@ -28,8 +95,6 @@ namespace Jellyfin.Plugin.HomeScreenSections.Configuration
         
         public bool Enabled { get; set; }
         
-        public bool AllowUserOverride { get; set; }
-        
         public int LowerLimit { get; set; }
         
         public int UpperLimit { get; set; }
@@ -37,5 +102,81 @@ namespace Jellyfin.Plugin.HomeScreenSections.Configuration
         public int OrderIndex { get; set; }
         
         public SectionViewMode ViewMode { get; set; } = SectionViewMode.Landscape;
+        
+        public string? CustomDisplayName { get; set; }
+        
+        public UserOverrideSetting[] UserOverrideSettings { get; set; } = new UserOverrideSetting[]
+        {
+            new UserOverrideSetting { Item = UserOverrideItem.CustomDisplayName, AllowUserOverride = true },
+            new UserOverrideSetting { Item = UserOverrideItem.EnableDisableSection, AllowUserOverride = true }
+        };
+
+        // Plugin-defined configuration options with admin default values
+        [XmlArray("PluginConfigurations")]
+        [XmlArrayItem("Entry")]
+        public PluginConfigurationEntry[] PluginConfigurations { get; set; } = Array.Empty<PluginConfigurationEntry>();
+        
+        // Helper method to get configuration value with type conversion
+        public T? GetPluginConfiguration<T>(string key, T? defaultValue = default)
+        {
+            var entry = PluginConfigurations?.FirstOrDefault(x => x.Key == key);
+            if (entry?.Value == null) return defaultValue;
+            
+            try
+            {
+                if (typeof(T) == typeof(bool))
+                {
+                    return (T)(object)bool.Parse(entry.Value);
+                }
+                else if (typeof(T) == typeof(int))
+                {
+                    return (T)(object)int.Parse(entry.Value);
+                }
+                else if (typeof(T) == typeof(double))
+                {
+                    return (T)(object)double.Parse(entry.Value);
+                }
+                else if (typeof(T) == typeof(decimal))
+                {
+                    return (T)(object)decimal.Parse(entry.Value);
+                }
+                else if (typeof(T) == typeof(string))
+                {
+                    return (T)(object)entry.Value;
+                }
+                else
+                {
+                    return defaultValue;
+                }
+            }
+            catch
+            {
+                return defaultValue;
+            }
+        }
+        
+        // Helper method to set configuration value
+        public void SetPluginConfiguration<T>(string key, T? value)
+        {
+            var entries = PluginConfigurations?.ToList() ?? new List<PluginConfigurationEntry>();
+            var existingEntry = entries.FirstOrDefault(x => x.Key == key);
+            
+            if (existingEntry != null)
+            {
+                existingEntry.Value = value?.ToString();
+                existingEntry.Type = typeof(T).Name.ToLower();
+            }
+            else
+            {
+                entries.Add(new PluginConfigurationEntry
+                {
+                    Key = key,
+                    Value = value?.ToString(),
+                    Type = typeof(T).Name.ToLower()
+                });
+            }
+            
+            PluginConfigurations = entries.ToArray();
+        }
     }
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
@@ -2,6 +2,54 @@
 <html lang="en" xmlns="http://www.w3.org/1999/html">
 <head>
     <title>Home Screen Sections</title>
+    <style>
+        .user-override-disabled {
+            opacity: 0.5 !important;
+            pointer-events: none !important;
+            transition: opacity 0.3s ease !important;
+        }
+        
+        .user-override-disabled input[type="checkbox"] {
+            opacity: 0.4 !important;
+            cursor: not-allowed !important;
+        }
+        
+        .user-override-disabled .checkboxLabel {
+            color: #666 !important;
+            cursor: not-allowed !important;
+        }
+        
+        .user-override-disabled td {
+            color: #888 !important;
+        }
+        
+        .user-override-content {
+            padding: 1em;
+            border: 1px solid rgba(255,255,255,0.15);
+            border-radius: 0.3em;
+            background-color: rgba(0,0,0,0.1);
+            margin-top: 1em;
+        }
+        
+        .user-override-content.hide {
+            display: none !important;
+        }
+        
+        .advanced-options {
+            display: none;
+        }
+        
+        .advanced-options.show {
+            display: block;
+        }
+        
+        .advanced-toggle {
+            margin: 1em 0;
+            padding: 0.5em;
+            background-color: rgba(255,255,255,0.05);
+            border-radius: 0.3em;
+        }
+    </style>
 </head>
 <body>
 <div data-role="page" id="homeScreenSectionsConfigurationPage" class="page type-interior pluginConfigurationPage fullWidthContent">
@@ -41,6 +89,17 @@
                     </label>
                     <div class="fieldDescription">Is the user allowed to enable/disable this plugin for their view?</div>
                 </div>
+                <div class="checkboxContainer checkboxContainer-withDescription">
+                    <label class="emby-checkbox-label">
+                        <input id="globalRespectUserHomepage" type="checkbox" is="emby-checkbox" data-embycheckbox="true" class="emby-checkbox">
+                        <span class="checkboxLabel">Respect User Homepage</span>
+                        <span class="checkboxOutline">
+                            <span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>
+                            <span class="material-icons checkboxIcon checkboxIcon-unchecked " aria-hidden="true"></span>
+                        </span>
+                    </label>
+                    <div class="fieldDescription">When enabled, the plugin will respect existing user homepage preferences and only apply to users who haven't set a custom homepage. When disabled, the plugin will override all user homepage settings.</div>
+                </div>
                 <div class="inputContainer">
                     <input is="emby-input" type="text" data-id="txtLibreTranslateUrl" label="LibreTranslate URL" />
                     <span>URL for LibreTranslate instance to use for translations.</span>
@@ -48,6 +107,30 @@
                 <div class="inputContainer">
                     <input is="emby-input" type="text" data-id="txtLibreTranslateApiKey" required="required" label="LibreTranslate API Key" />
                     <span>API Key for LibreTranslate instance.</span>
+                </div>
+                <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="defaultMoviesLibrary">Default Movies Library</label>
+                    <select is="emby-select" id="defaultMoviesLibrary" class="emby-select-withcolor emby-select">
+                        <option value="">Default</option>
+                    </select>
+                    <div class="fieldDescription">Select the specific movies library to use for navigation. Lists all underlying library folders (not grouped views). <strong>Requires Jellyfin restart to take effect.</strong></div>
+                </div>
+                <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="defaultTVShowsLibrary">Default TV Shows Library</label>
+                    <select is="emby-select" id="defaultTVShowsLibrary" class="emby-select-withcolor emby-select">
+                        <option value="">Default</option>
+                    </select>
+                    <div class="fieldDescription">Select the specific TV shows library to use for navigation. Lists all underlying library folders (not grouped views). <strong>Requires Jellyfin restart to take effect.</strong></div>
+                </div>
+                <div class="advanced-toggle">
+                    <label class="emby-checkbox-label">
+                        <input id="showAdvancedOptions" type="checkbox" is="emby-checkbox" data-embycheckbox="true" class="emby-checkbox">
+                        <span class="checkboxLabel">Show Advanced Options</span>
+                        <span class="checkboxOutline">
+                            <span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>
+                            <span class="material-icons checkboxIcon checkboxIcon-unchecked" aria-hidden="true"></span>
+                        </span>
+                    </label>
                 </div>
             </fieldset>
             <fieldset class="verticalSection-extrabottompadding">
@@ -72,27 +155,51 @@
                 <input id="templateOrderIndex" data-id="txtOrderIndex" type="number" is="emby-input" min="0" class="emby-input">
                 <div class="fieldDescription">Defines an order location for this section, the smaller the number the higher it will appear on the home page. <i>Note: When sections share a number they will be randomized among themselves.</i></div>
             </div>
-            <div class="checkboxContainer checkboxContainer-withDescription">
-                <label class="emby-checkbox-label">
-                    <input id="templateSectionEnabled" data-id="chkSectionEnabled" type="checkbox" is="emby-checkbox" data-embycheckbox="true" class="emby-checkbox">
-                    <span class="checkboxLabel">Enabled</span>
-                    <span class="checkboxOutline">
-                        <span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>
-                        <span class="material-icons checkboxIcon checkboxIcon-unchecked " aria-hidden="true"></span>
-                    </span>
-                </label>
-                <div class="fieldDescription">Is this section enabled by default?</div>
+            
+            <div class="verticalSection-extrabottompadding">
+                <h4>Default Settings</h4>
+                <div class="checkboxContainer checkboxContainer-withDescription">
+                    <label class="emby-checkbox-label">
+                        <input id="templateSectionEnabled" data-id="chkSectionEnabled" type="checkbox" is="emby-checkbox" data-embycheckbox="true" class="emby-checkbox">
+                        <span class="checkboxLabel">Enabled</span>
+                        <span class="checkboxOutline">
+                            <span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>
+                            <span class="material-icons checkboxIcon checkboxIcon-unchecked " aria-hidden="true"></span>
+                        </span>
+                    </label>
+                    <div class="fieldDescription">Is this section enabled by default?</div>
+                </div>
+                
+                <div class="inputContainer advanced-options">
+                    <label class="inputLabel inputLabelUnfocused" for="templateCustomDisplayName">Custom Display Name</label>
+                    <input id="templateCustomDisplayName" data-id="txtCustomDisplayName" type="text" is="emby-input" class="emby-input">
+                    <div class="fieldDescription">Override the default display name for this section. Leave blank to use the default name.</div>
+                </div>
+                
+                <!-- Dynamic Configuration Options Placeholder -->
+                <div data-id="dynamicConfigContainer"></div>
             </div>
-            <div class="checkboxContainer checkboxContainer-withDescription">
-                <label class="emby-checkbox-label">
-                    <input id="templateSectionAllowUserOverride" data-id="chkSectionUserOverrideAllowed" type="checkbox" is="emby-checkbox" data-embycheckbox="true" class="emby-checkbox">
-                    <span class="checkboxLabel">Allow User Override</span>
-                    <span class="checkboxOutline">
-                        <span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>
-                        <span class="material-icons checkboxIcon checkboxIcon-unchecked " aria-hidden="true"></span>
-                    </span>
-                </label>
-                <div class="fieldDescription">Is the user allowed to enable/disable this section?</div>
+            
+            <div class="verticalSection-extrabottompadding">
+                <h4>User Override Settings</h4>
+                
+                <div class="checkboxContainer checkboxContainer-withDescription" style="margin-bottom: 15px;">
+                    <label class="emby-checkbox-label">
+                        <input id="allowUserOverrideToggle" data-id="chkAllowUserOverride" type="checkbox" is="emby-checkbox" data-embycheckbox="true" class="emby-checkbox">
+                        <span class="checkboxLabel">Allow User Override</span>
+                        <span class="checkboxOutline">
+                            <span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>
+                            <span class="material-icons checkboxIcon checkboxIcon-unchecked" aria-hidden="true"></span>
+                        </span>
+                    </label>
+                    <div class="fieldDescription">Enable this to allow users to customize this section's settings.</div>
+                </div>
+                
+                <div class="user-override-content hide advanced-options" data-id="userOverrideContent">
+                    <div id="userOverrideContainer" data-id="userOverrideContainer">
+                        <!-- User override settings -->
+                    </div>
+                </div>
             </div>
             <div class="inputContainer">
                 <span>View Mode: </span>
@@ -128,6 +235,39 @@
                 btnSave: document.querySelector('#btnSaveConfig'),
                 init: function () {
                     HomeScreenSections.loadConfig();
+                    HomeScreenSections.loadLibraries();
+                    HomeScreenSections.setupAdvancedToggle();
+                },
+                loadLibraries: function () {
+                    window.ApiClient.getVirtualFolders().then(function (result) {
+                        const moviesSelect = document.querySelector('#defaultMoviesLibrary');
+                        const tvShowsSelect = document.querySelector('#defaultTVShowsLibrary');
+                        
+                        moviesSelect.innerHTML = '<option value="">Default</option>';
+                        tvShowsSelect.innerHTML = '<option value="">Default</option>';
+                        
+                        result.filter(folder => folder.CollectionType === 'movies').forEach(function (folder) {
+                            const option = document.createElement('option');
+                            let folderId = folder.ItemId;
+                            if (folderId && !folderId.includes('-')) {
+                                folderId = folderId.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5');
+                            }
+                            option.value = folderId;
+                            option.textContent = folder.Name;
+                            moviesSelect.appendChild(option);
+                        });
+                        
+                        result.filter(folder => folder.CollectionType === 'tvshows').forEach(function (folder) {
+                            const option = document.createElement('option');
+                            let folderId = folder.ItemId;
+                            if (folderId && !folderId.includes('-')) {
+                                folderId = folderId.replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5');
+                            }
+                            option.value = folderId;
+                            option.textContent = folder.Name;
+                            tvShowsSelect.appendChild(option);
+                        });
+                    }).catch(function (error) {});
                 },
                 saveConfig: function (e) {
                     e.preventDefault();
@@ -135,46 +275,147 @@
                     const config = {
                         Enabled: document.querySelector('#globalEnabledDefault').checked,
                         AllowUserOverride: document.querySelector('#globalAllowUserOverride').checked,
+                        RespectUserHomepage: document.querySelector('#globalRespectUserHomepage').checked,
                         LibreTranslateUrl: document.querySelector('[data-id=txtLibreTranslateUrl]').value,
                         LibreTranslateApiKey: document.querySelector('[data-id=txtLibreTranslateApiKey]').value,
+                        DefaultMoviesLibraryId: document.querySelector('#defaultMoviesLibrary').value,
+                        DefaultTVShowsLibraryId: document.querySelector('#defaultTVShowsLibrary').value,
                         SectionSettings: []
                     };
                     
                     const configs = document.querySelectorAll('[data-id=section-config]');
                     for (let i = 0; i < configs.length; i++) {
+                        const allowUserOverrideToggle = configs[i].querySelector('[data-id="chkAllowUserOverride"]');
+                        const userOverrideEnabled = allowUserOverrideToggle ? allowUserOverrideToggle.checked : false;
+                        
+                        const userOverrideSettings = [];
+                        const overrideCheckboxes = configs[i].querySelectorAll('[data-override-item]');
+                        overrideCheckboxes.forEach(function(checkbox) {
+                            if (!checkbox.hasAttribute('data-plugin-config')) {
+                                userOverrideSettings.push({
+                                    Item: checkbox.getAttribute('data-override-item'),
+                                    AllowUserOverride: userOverrideEnabled && checkbox.checked
+                                });
+                            }
+                        });
+                        
+                        const pluginConfigurations = [];
+                        const pluginConfigElements = configs[i].querySelectorAll('[data-id^="pluginConfig_"]');
+                        pluginConfigElements.forEach(function(element) {
+                            const key = element.getAttribute('data-id').replace('pluginConfig_', '');
+                            let value;
+                            let type = 'string';
+                            
+                            if (element.type === 'checkbox') {
+                                value = element.checked;
+                                type = 'bool';
+                            } else if (element.type === 'number') {
+                                value = element.value ? parseFloat(element.value) : null;
+                                type = 'double';
+                            } else {
+                                value = element.value;
+                                type = 'string';
+                            }
+                            
+                            if (value !== null && value !== '') {
+                                pluginConfigurations.push({
+                                    Key: key,
+                                    Value: value?.toString(),
+                                    Type: type
+                                });
+                            }
+                        });
+
                         const sectionConfig = {
                             SectionId: configs[i].querySelector('[data-id=hiddenSectionId]').value,
                             Enabled: configs[i].querySelector('[data-id=chkSectionEnabled]').checked,
-                            AllowUserOverride: configs[i].querySelector('[data-id=chkSectionUserOverrideAllowed]').checked,
-                            LowerLimit: configs[i].querySelector('[data-id=txtSectionMinLimit]').value,
-                            UpperLimit: configs[i].querySelector('[data-id=txtSectionMaxLimit]').value,
-                            OrderIndex: configs[i].querySelector('[data-id=txtOrderIndex]').value,
+                            LowerLimit: parseInt(configs[i].querySelector('[data-id=txtSectionMinLimit]').value) || 1,
+                            UpperLimit: parseInt(configs[i].querySelector('[data-id=txtSectionMaxLimit]').value) || 1,
+                            OrderIndex: parseInt(configs[i].querySelector('[data-id=txtOrderIndex]').value) || 999,
                             ViewMode: configs[i].querySelector('[data-id=viewModeSelect]').value,
+                            CustomDisplayName: configs[i].querySelector('[data-id=txtCustomDisplayName]').value,
+                            PluginConfigurations: pluginConfigurations,
+                            UserOverrideSettings: userOverrideSettings
                         };
                         
                         config.SectionSettings.push(sectionConfig);
                     }
                     
-                    window.ApiClient.updatePluginConfiguration(HomeScreenSections.pluginId, config)
-                        .then(Dashboard.processPluginConfigurationUpdateResult)
-                        .catch(function (error) {
-                            console.log(error);
-                        })
-                        .finally(function () {
-                            Dashboard.hideLoadingMsg();
-                        });
+                    const authScheme = window.ApiClient.authenticationScheme || 'MediaBrowser';
+                    const accessToken = window.ApiClient.accessToken();
+                    const authHeader = authScheme + ' ' + accessToken;
+                    
+                    fetch(window.location.protocol + '//' + window.location.host + '/HomeScreen/Configuration', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'Authorization': authHeader
+                        },
+                        body: JSON.stringify(config)
+                    })
+                    .then(response => {
+                        if (!response.ok) {
+                            return response.text().then(text => {
+                                return window.ApiClient.updatePluginConfiguration(HomeScreenSections.pluginId, config);
+                            });
+                        }
+                        return response;
+                    })
+                    .then(() => {
+                        if (typeof Dashboard !== 'undefined' && Dashboard.processPluginConfigurationUpdateResult) {
+                            Dashboard.processPluginConfigurationUpdateResult();
+                        } else {
+                            Dashboard.alert('Settings have been updated.');
+                        }
+                    })
+                    .catch(function (error) {
+                        if (typeof Dashboard !== 'undefined' && Dashboard.processErrorResponse) {
+                            Dashboard.processErrorResponse(error);
+                        } else {
+                            Dashboard.alert('Error saving configuration: ' + error.message);
+                        }
+                    })
+                    .finally(function () {
+                        Dashboard.hideLoadingMsg();
+                    });
                 },
                 loadConfig: function() {
                     Dashboard.showLoadingMsg();
-                    window.ApiClient.getPluginConfiguration(HomeScreenSections.pluginId)
-                        .then(function (config) {
+                    
+                    const authScheme = window.ApiClient.authenticationScheme || 'MediaBrowser';
+                    const accessToken = window.ApiClient.accessToken();
+                    const authHeader = authScheme + ' ' + accessToken;
+                    
+                    fetch(window.location.protocol + '//' + window.location.host + '/HomeScreen/Configuration', {
+                        method: 'GET',
+                        headers: {
+                            'Authorization': authHeader
+                        }
+                    })
+                    .then(response => {
+                        if (!response.ok) {
+                            return response.text().then(text => {
+                                return window.ApiClient.getPluginConfiguration(HomeScreenSections.pluginId);
+                            });
+                        }
+                        return response.json();
+                    })
+                    .then(function (config) {
                             document.querySelector('#globalEnabledDefault').checked = config.Enabled;
                             document.querySelector('#globalAllowUserOverride').checked = config.AllowUserOverride;
+                            document.querySelector('#globalRespectUserHomepage').checked = config.RespectUserHomepage !== false;
                             document.querySelector('[data-id=txtLibreTranslateUrl]').value = config.LibreTranslateUrl;
                             document.querySelector('[data-id=txtLibreTranslateApiKey]').value = config.LibreTranslateApiKey;
                             
-                            // Get plugin defaults for each section it defines
-                            // Loop over these sections and add in what the config has overwritten
+                            setTimeout(function() {
+                                if (config.DefaultMoviesLibraryId) {
+                                    document.querySelector('#defaultMoviesLibrary').value = config.DefaultMoviesLibraryId;
+                                }
+                                if (config.DefaultTVShowsLibraryId) {
+                                    document.querySelector('#defaultTVShowsLibrary').value = config.DefaultTVShowsLibraryId;
+                                }
+                            }, 500);
+                            
                             let urlStart = window.location.protocol + '//' + window.location.host;
                             window.ApiClient.ajax({
                                 url: ApiClient.getUrl('ModularHomeViews/Sections'),
@@ -185,21 +426,23 @@
                                 });
                             })
                             .catch(function (error) {
-                                console.error(error);
-                            })
-                            .finally(function () {
                                 Dashboard.hideLoadingMsg();
                             });
+                        })
+                        .catch(function (error) {
+                            Dashboard.hideLoadingMsg();
                         });
                 },
                 loadConfigResponse: function(pluginConfig, sectionTypes) {
-                    // clear the "sections"
+                    HomeScreenSections.sectionWrapper.innerHTML = '';
+                    
                     for (let i = 0; i < sectionTypes.length; ++i) {
                         let found = false;
                         for (let j = 0; j < pluginConfig.SectionSettings.length; ++j) {
                             if (pluginConfig.SectionSettings[j].SectionId == sectionTypes[i].Section) {
                                 HomeScreenSections.addSectionSetting(pluginConfig.SectionSettings[j], sectionTypes[i]);
                                 found = true;
+                                break;
                             }
                         }
                         
@@ -207,27 +450,34 @@
                             let newConfig = {
                                 SectionId: sectionTypes[i].Section,
                                 Enabled: true,
-                                AllowUserOverride: true,
                                 LowerLimit: 1,
                                 UpperLimit: sectionTypes[i].Limit,
                                 ViewMode: sectionTypes[i].ViewMode,
-                                OrderIndex: 999 // new sections will always appear last to avoid admins orders being screwed
+                                OrderIndex: 999,
+                                CustomDisplayName: '',
+                                PluginConfigurations: [],
+                                UserOverrideSettings: [
+                                    { Item: 'EnableDisableSection', AllowUserOverride: true },
+                                    { Item: 'CustomDisplayName', AllowUserOverride: true }
+                                ]
                             };
                             
                             HomeScreenSections.addSectionSetting(newConfig, sectionTypes[i]);
                         }
                     }
                     
+                    Dashboard.hideLoadingMsg();
                 },
                 addSectionSetting: function(sectionConfig, sectionInfo) {
                     const template = HomeScreenSections.sectionTemplate.cloneNode(true).content;
                     template.querySelector('[data-id=hiddenSectionId]').value = sectionConfig.SectionId;
                     template.querySelector('[data-id=chkSectionEnabled]').checked = sectionConfig.Enabled;
-                    template.querySelector('[data-id=chkSectionUserOverrideAllowed]').checked = sectionConfig.AllowUserOverride;
                     template.querySelector('[data-id=txtSectionMinLimit]').value = sectionConfig.LowerLimit;
                     template.querySelector('[data-id=txtSectionMaxLimit]').value = sectionConfig.UpperLimit;
                     template.querySelector('[data-id=txtOrderIndex]').value = sectionConfig.OrderIndex;
                     template.querySelector('[data-id=viewModeSelect]').value = sectionConfig.ViewMode;
+                    template.querySelector('[data-id=txtCustomDisplayName]').value = sectionConfig.CustomDisplayName || '';
+                    
                     if (!sectionInfo.AllowViewModeChange) {
                         template.querySelector('[data-id=viewModeSelect]').value = sectionInfo.ViewMode;
                         template.querySelector('[data-id=viewModeSelect]').setAttribute('disabled', true)
@@ -235,7 +485,338 @@
                     
                     template.querySelector('[data-id=lblSectionName]').innerHTML = sectionInfo.DisplayText;
                     
-                    const el = HomeScreenSections.sectionWrapper.appendChild(template);
+                    HomeScreenSections.sectionWrapper.appendChild(template);
+                    
+                    const allSections = HomeScreenSections.sectionWrapper.querySelectorAll('[data-id=section-config]');
+                    const el = allSections[allSections.length - 1];
+                    
+                    HomeScreenSections.populateDynamicConfigOptions(el, sectionConfig, sectionInfo);
+                    
+                    const userOverrideContainer = el.querySelector('[data-id=userOverrideContainer]');
+                    HomeScreenSections.populateUserOverrideSettings(userOverrideContainer, sectionConfig, el, sectionInfo);
+                },
+                populateDynamicConfigOptions: async function(sectionElement, sectionConfig, sectionInfo) {
+                    try {
+                        const baseUrl = window.location.protocol + '//' + window.location.host;
+                        const url = baseUrl + '/HomeScreen/Section/' + sectionInfo.Section + '/ConfigurationOptions';
+                        const response = await fetch(url);
+                        
+                        if (!response.ok) {
+                            return;
+                        }
+                        
+                        const responseText = await response.text();
+                        
+                        let configOptions;
+                        try {
+                            configOptions = JSON.parse(responseText);
+                        } catch (e) {
+                            return;
+                        }
+                        const dynamicContainer = sectionElement.querySelector('[data-id=dynamicConfigContainer]');
+                        
+                        if (!dynamicContainer) {
+                            return;
+                        }
+                        
+                        // Clear existing content
+                        dynamicContainer.innerHTML = '';
+                        
+                        // Create controls for each configuration option
+                        configOptions.forEach(option => {
+                            const controlElement = HomeScreenSections.createConfigControl(option, sectionConfig);
+                            if (controlElement) {
+                                dynamicContainer.appendChild(controlElement);
+                            }
+                        });
+                        
+                    } catch (error) {
+                    }
+                },
+                createConfigControl: function(option, sectionConfig) {
+                    // Find current value in the array format
+                    let currentValue = option.DefaultValue;
+                    if (sectionConfig.PluginConfigurations && Array.isArray(sectionConfig.PluginConfigurations)) {
+                        const entry = sectionConfig.PluginConfigurations.find(c => c.Key === option.Key);
+                        if (entry && entry.Value !== null && entry.Value !== undefined) {
+                            // Convert value based on type
+                            if (entry.Type === 'bool' || option.Type === 'Checkbox') {
+                                currentValue = entry.Value === 'true' || entry.Value === true;
+                            } else if (entry.Type === 'double' || entry.Type === 'int' || option.Type === 'NumberBox') {
+                                currentValue = parseFloat(entry.Value);
+                            } else {
+                                currentValue = entry.Value;
+                            }
+                        }
+                    }
+                    
+                    switch (option.Type) {
+                        case 'Checkbox':
+                            return HomeScreenSections.createCheckboxControl(option, currentValue);
+                        case 'Dropdown':
+                            return HomeScreenSections.createDropdownControl(option, currentValue);
+                        case 'TextBox':
+                            return HomeScreenSections.createTextBoxControl(option, currentValue);
+                        case 'NumberBox':
+                            return HomeScreenSections.createNumberBoxControl(option, currentValue);
+                        default:
+                            return null;
+                    }
+                },
+                createCheckboxControl: function(option, currentValue) {
+                    const container = document.createElement('div');
+                    container.className = 'checkboxContainer checkboxContainer-withDescription';
+                    container.innerHTML = `
+                        <label class="emby-checkbox-label">
+                            <input data-id="pluginConfig_` + option.Key + `" type="checkbox" is="emby-checkbox" data-embycheckbox="true" class="emby-checkbox" ` + (currentValue ? 'checked' : '') + `>
+                            <span class="checkboxLabel">` + option.Name + `</span>
+                            <span class="checkboxOutline">
+                                <span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>
+                                <span class="material-icons checkboxIcon checkboxIcon-unchecked " aria-hidden="true"></span>
+                            </span>
+                        </label>
+                        <div class="fieldDescription">` + (option.Description || '') + `</div>
+                    `;
+                    return container;
+                },
+                createDropdownControl: function(option, currentValue) {
+                    const container = document.createElement('div');
+                    container.className = 'selectContainer';
+                    
+                    let optionsHtml = '';
+                    if (option.DropdownOptions && option.DropdownLabels) {
+                        for (let i = 0; i < option.DropdownOptions.length; i++) {
+                            const selected = option.DropdownOptions[i] === currentValue ? 'selected' : '';
+                            const label = option.DropdownLabels[i] || option.DropdownOptions[i];
+                            optionsHtml += '<option value="' + option.DropdownOptions[i] + '" ' + selected + '>' + label + '</option>';
+                        }
+                    }
+                    
+                    container.innerHTML = `
+                        <label class="inputLabel inputLabelUnfocused" for="pluginConfig_` + option.Key + `">` + option.Name + `</label>
+                        <select data-id="pluginConfig_` + option.Key + `" is="emby-select" class="emby-select-withcolor emby-select">
+                            ` + optionsHtml + `
+                        </select>
+                        <div class="fieldDescription">` + (option.Description || '') + `</div>
+                    `;
+                    return container;
+                },
+                createTextBoxControl: function(option, currentValue) {
+                    const container = document.createElement('div');
+                    container.className = 'inputContainer';
+                    
+                    const patternAttr = option.Pattern ? ('pattern="' + option.Pattern + '"') : '';
+                    
+                    container.innerHTML = `
+                        <label class="inputLabel inputLabelUnfocused" for="pluginConfig_` + option.Key + `">` + option.Name + `</label>
+                        <input data-id="pluginConfig_` + option.Key + `" type="text" is="emby-input" class="emby-input" value="` + (currentValue || '') + `" ` + patternAttr + `>
+                        <div class="fieldDescription">` + (option.Description || '') + `</div>
+                    `;
+                    return container;
+                },
+                createNumberBoxControl: function(option, currentValue) {
+                    const container = document.createElement('div');
+                    container.className = 'inputContainer';
+                    
+                    const minAttr = option.MinValue !== undefined ? ('min="' + option.MinValue + '"') : '';
+                    const maxAttr = option.MaxValue !== undefined ? ('max="' + option.MaxValue + '"') : '';
+                    
+                    container.innerHTML = `
+                        <label class="inputLabel inputLabelUnfocused" for="pluginConfig_` + option.Key + `">` + option.Name + `</label>
+                        <input data-id="pluginConfig_` + option.Key + `" type="number" is="emby-input" class="emby-input" value="` + (currentValue || option.DefaultValue || '') + `" ` + minAttr + ` ` + maxAttr + `>
+                        <div class="fieldDescription">` + (option.Description || '') + `</div>
+                    `;
+                    return container;
+                },
+                populateUserOverrideSettings: async function(container, sectionConfig, sectionElement, sectionInfo) {
+                    if (!container) {
+                        return;
+                    }
+                    
+                    // Get configuration options for dynamic override items
+                    let configOptions = [];
+                    try {
+                        const baseUrl = window.location.protocol + '//' + window.location.host;
+                        const url = baseUrl + '/HomeScreen/Section/' + sectionInfo.Section + '/ConfigurationOptions';
+                        const response = await fetch(url);
+                        if (response.ok) {
+                            configOptions = await response.json();
+                        } else {
+                        }
+                    } catch (error) {
+                    }
+                    
+                    if (!sectionConfig.UserOverrideSettings) {
+                        sectionConfig.UserOverrideSettings = [
+                            { Item: 'EnableDisableSection', AllowUserOverride: true },
+                            { Item: 'CustomDisplayName', AllowUserOverride: true }
+                        ];
+                    }
+                    
+                    let html = '<table style="width: 100%; border-collapse: collapse;">';
+                    html += '<thead><tr>';
+                    html += '<th style="text-align: left; padding: 8px; border-bottom: 1px solid #444;">Allow User Override</th>';
+                    html += '<th style="text-align: left; padding: 8px; border-bottom: 1px solid #444;">Item</th>';
+                    html += '</tr></thead><tbody>';
+                    
+                    let availableItems = [
+                        { key: 'EnableDisableSection', label: 'Enable/Disable this section' },
+                        { key: 'CustomDisplayName', label: 'Custom Display Name' }
+                    ];
+                    
+                    configOptions.forEach(function(option) {
+                        if (option.AllowUserOverride === true) {
+                            availableItems.push({
+                                key: option.Key,
+                                label: option.Name + (option.Description ? ' (' + option.Description + ')' : ''),
+                                isPluginConfig: true
+                            });
+                        }
+                    });
+                    
+                    availableItems.forEach(function(item) {
+                        let existingSetting;
+                        let isAllowed;
+                        
+                        if (item.isPluginConfig) {
+                            const configOption = configOptions.find(o => o.Key === item.key);
+                            isAllowed = configOption ? configOption.AllowUserOverride : false;
+                        } else {
+                            existingSetting = sectionConfig.UserOverrideSettings.find(s => s.Item === item.key);
+                            isAllowed = existingSetting ? existingSetting.AllowUserOverride : true;
+                        }
+                        
+                        html += '<tr>';
+                        html += '<td style="padding: 8px; border-bottom: 1px solid #333;">';
+                        html += '<label class="emby-checkbox-label">';
+                        html += '<input type="checkbox" is="emby-checkbox" data-override-item="' + item.key + '" ' + (isAllowed ? 'checked' : '') + ' data-embycheckbox="true" class="emby-checkbox"' + (item.isPluginConfig ? ' data-plugin-config="true"' : '') + '>';
+                        html += '<span class="checkboxLabel"></span>';
+                        html += '<span class="checkboxOutline">';
+                        html += '<span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>';
+                        html += '<span class="material-icons checkboxIcon checkboxIcon-unchecked" aria-hidden="true"></span>';
+                        html += '</span>';
+                        html += '</label>';
+                        html += '</td>';
+                        html += '<td style="padding: 8px; border-bottom: 1px solid #333;">' + item.label + '</td>';
+                        html += '</tr>';
+                    });
+                    
+                    html += '</tbody></table>';
+                    container.innerHTML = html;
+                    
+                    // Set up the Allow User Override toggle
+                    const allowUserOverrideToggle = sectionElement.querySelector('[data-id="chkAllowUserOverride"]');
+                    const userOverrideTable = container.querySelector('table');
+                    
+                    if (!allowUserOverrideToggle || !userOverrideTable) {
+                        return; // Exit if elements not found
+                    }
+                    
+                    // Determine if any user overrides are currently enabled
+                    const hasAnyOverrideEnabled = sectionConfig.UserOverrideSettings.some(s => s.AllowUserOverride);
+                    allowUserOverrideToggle.checked = hasAnyOverrideEnabled;
+                    
+                    // Set initial state
+                    toggleUserOverrideSettings(userOverrideTable, hasAnyOverrideEnabled);
+                    
+                    // Set initial visibility of the override content
+                    const userOverrideContent = sectionElement.querySelector('[data-id="userOverrideContent"]');
+                    if (userOverrideContent) {
+                        if (hasAnyOverrideEnabled) {
+                            userOverrideContent.classList.remove('hide');
+                            // Check both advanced toggle and saved state
+                            const advancedToggle = document.getElementById('showAdvancedOptions');
+                            const savedAdvancedState = localStorage.getItem('homeScreenSections.adminConfig.showAdvanced');
+                            if (!advancedToggle || (!advancedToggle.checked && savedAdvancedState !== 'true')) {
+                                userOverrideContent.style.display = 'none';
+                            }
+                        } else {
+                            userOverrideContent.classList.add('hide');
+                            userOverrideContent.style.display = 'none';
+                        }
+                    }
+                    
+                    // Add event listener for the toggle
+                    allowUserOverrideToggle.addEventListener('change', function() {
+                        const isEnabled = this.checked;
+                        toggleUserOverrideSettings(userOverrideTable, isEnabled);
+                        
+                        // Show/hide the override content based on checkbox state
+                        if (userOverrideContent) {
+                            if (isEnabled) {
+                                userOverrideContent.classList.remove('hide');
+                                // Also check if advanced toggle is enabled (including saved state)
+                                const advancedToggle = document.getElementById('showAdvancedOptions');
+                                const savedAdvancedState = localStorage.getItem('homeScreenSections.adminConfig.showAdvanced');
+                                if (advancedToggle && (advancedToggle.checked || savedAdvancedState === 'true')) {
+                                    userOverrideContent.style.display = 'block';
+                                }
+                            } else {
+                                userOverrideContent.classList.add('hide');
+                                userOverrideContent.style.display = 'none';
+                            }
+                        }
+                        
+                        // Don't modify checkbox states, just enable/disable them visually
+                        // The checkboxes retain their values but are grayed out when disabled
+                    });
+                    
+                    function toggleUserOverrideSettings(tableElement, isEnabled) {
+                        if (isEnabled) {
+                            tableElement.classList.remove('user-override-disabled');
+                        } else {
+                            tableElement.classList.add('user-override-disabled');
+                        }
+                    }
+                },
+                
+                setupAdvancedToggle: function() {
+                    const advancedToggle = document.getElementById('showAdvancedOptions');
+                    if (advancedToggle) {
+                        // Restore saved state from localStorage
+                        const savedState = localStorage.getItem('homeScreenSections.adminConfig.showAdvanced');
+                        if (savedState === 'true') {
+                            advancedToggle.checked = true;
+                            // Apply the state immediately
+                            const advancedOptions = document.querySelectorAll('.advanced-options');
+                            advancedOptions.forEach(function(element) {
+                                // For user override content, we need to respect both the hide class and advanced toggle
+                                if (element.classList.contains('user-override-content')) {
+                                    // Only show if it's not hidden by the user override toggle
+                                    if (!element.classList.contains('hide')) {
+                                        element.style.display = 'block';
+                                    }
+                                } else {
+                                    element.style.display = 'block';
+                                }
+                            });
+                        }
+                        
+                        advancedToggle.addEventListener('change', function() {
+                            const advancedOptions = document.querySelectorAll('.advanced-options');
+                            if (this.checked) {
+                                advancedOptions.forEach(function(element) {
+                                    // For user override content, we need to respect both the hide class and advanced toggle
+                                    if (element.classList.contains('user-override-content')) {
+                                        // Only show if it's not hidden by the user override toggle
+                                        if (!element.classList.contains('hide')) {
+                                            element.style.display = 'block';
+                                        }
+                                    } else {
+                                        element.style.display = 'block';
+                                    }
+                                });
+                                // Save state to localStorage
+                                localStorage.setItem('homeScreenSections.adminConfig.showAdvanced', 'true');
+                            } else {
+                                advancedOptions.forEach(function(element) {
+                                    element.style.display = 'none';
+                                });
+                                // Save state to localStorage
+                                localStorage.setItem('homeScreenSections.adminConfig.showAdvanced', 'false');
+                            }
+                        });
+                    }
                 }
             }
 

--- a/src/Jellyfin.Plugin.HomeScreenSections/Controllers/HomeScreenController.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Controllers/HomeScreenController.cs
@@ -326,7 +326,6 @@ namespace Jellyfin.Plugin.HomeScreenSections.Controllers
         }
 
         [HttpPost("RegisterSection")]
-        [Authorize(Policy = "RequiresElevation")]
         public ActionResult RegisterSection([FromBody] SectionRegisterPayload payload)
         {
             m_homeScreenManager.RegisterResultsDelegate(new PluginDefinedSection(payload.Id, payload.DisplayText!, payload.Route, payload.AdditionalData, payload.ConfigurationOptions)

--- a/src/Jellyfin.Plugin.HomeScreenSections/Controllers/loadSections.js
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Controllers/loadSections.js
@@ -127,7 +127,7 @@
     }
     
     async function isUserUsingHomeScreenSections(_userSettings, _apiClient) {
-        var pluginConfig = await _apiClient.getJSON(_apiClient.getUrl("HomeScreen/Configuration"));
+        var pluginConfig = await _apiClient.getJSON(_apiClient.getUrl("HomeScreen/Status"));
         
         if (pluginConfig.AllowUserOverride === true) {
             if (_userSettings && _userSettings.getData() && _userSettings.getData().CustomPrefs && _userSettings.getData().CustomPrefs.useModularHome !== undefined) {

--- a/src/Jellyfin.Plugin.HomeScreenSections/Controllers/loadSections.js
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Controllers/loadSections.js
@@ -1,4 +1,17 @@
 ﻿async function test(elem, apiClient, user, userSettings) {
+    if (!isHomePage()) {
+        return;
+    }
+
+    function isHomePage() {
+        const hasIndexPageId = document.getElementById('indexPage') !== null;
+        const hasHomePageClass = document.querySelector('.page.homePage') !== null;
+        const hasSectionsDiv = document.querySelector('.sections') !== null;
+        const hasPageRole = document.querySelector('[data-role="page"]') !== null;
+        
+        return hasIndexPageId && hasHomePageClass && hasSectionsDiv && hasPageRole;
+    }
+    
     function getHomeScreenSectionFetchFn(serverId, sectionInfo, serverConnections, _userSettings) {
         return function() {
             var __userSettings = _userSettings;

--- a/src/Jellyfin.Plugin.HomeScreenSections/Controllers/loadSections.js
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Controllers/loadSections.js
@@ -3,6 +3,13 @@
         return;
     }
 
+    const refreshNeeded = localStorage.getItem('homeScreenSections.refreshNeeded');
+    if (refreshNeeded === 'true') {
+        localStorage.removeItem('homeScreenSections.refreshNeeded');
+        window.location.reload();
+        return;
+    }
+
     function isHomePage() {
         const hasIndexPageId = document.getElementById('indexPage') !== null;
         const hasHomePageClass = document.querySelector('.page.homePage') !== null;

--- a/src/Jellyfin.Plugin.HomeScreenSections/Extensions/PluginConfigurationExtensions.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Extensions/PluginConfigurationExtensions.cs
@@ -1,0 +1,75 @@
+using Jellyfin.Plugin.HomeScreenSections.Model.Dto;
+
+namespace Jellyfin.Plugin.HomeScreenSections.Extensions
+{
+    /// <summary>
+    /// Extension methods to simplify configuration access for external plugins
+    /// </summary>
+    public static class PluginConfigurationExtensions
+    {
+        /// <summary>
+        /// Gets a boolean configuration value for the specified section and key
+        /// </summary>
+        /// <param name="payload">The section payload</param>
+        /// <param name="sectionId">The section identifier</param>
+        /// <param name="configKey">The configuration key</param>
+        /// <param name="defaultValue">Default value if not found</param>
+        /// <returns>The effective boolean configuration value</returns>
+        public static bool GetBoolConfig(this HomeScreenSectionPayload payload, string sectionId, string configKey, bool defaultValue = false)
+        {
+            return payload.GetEffectivePluginConfiguration<bool>(sectionId, configKey, defaultValue);
+        }
+
+        /// <summary>
+        /// Gets a string configuration value for the specified section and key
+        /// </summary>
+        /// <param name="payload">The section payload</param>
+        /// <param name="sectionId">The section identifier</param>
+        /// <param name="configKey">The configuration key</param>
+        /// <param name="defaultValue">Default value if not found</param>
+        /// <returns>The effective string configuration value</returns>
+        public static string GetStringConfig(this HomeScreenSectionPayload payload, string sectionId, string configKey, string defaultValue = "")
+        {
+            return payload.GetEffectivePluginConfiguration<string>(sectionId, configKey, defaultValue);
+        }
+
+        /// <summary>
+        /// Gets an integer configuration value for the specified section and key
+        /// </summary>
+        /// <param name="payload">The section payload</param>
+        /// <param name="sectionId">The section identifier</param>
+        /// <param name="configKey">The configuration key</param>
+        /// <param name="defaultValue">Default value if not found</param>
+        /// <returns>The effective integer configuration value</returns>
+        public static int GetIntConfig(this HomeScreenSectionPayload payload, string sectionId, string configKey, int defaultValue = 0)
+        {
+            return payload.GetEffectivePluginConfiguration<int>(sectionId, configKey, defaultValue);
+        }
+
+        /// <summary>
+        /// Gets a double configuration value for the specified section and key
+        /// </summary>
+        /// <param name="payload">The section payload</param>
+        /// <param name="sectionId">The section identifier</param>
+        /// <param name="configKey">The configuration key</param>
+        /// <param name="defaultValue">Default value if not found</param>
+        /// <returns>The effective double configuration value</returns>
+        public static double GetDoubleConfig(this HomeScreenSectionPayload payload, string sectionId, string configKey, double defaultValue = 0.0)
+        {
+            return payload.GetEffectivePluginConfiguration<double>(sectionId, configKey, defaultValue);
+        }
+
+        /// <summary>
+        /// Gets a decimal configuration value for the specified section and key
+        /// </summary>
+        /// <param name="payload">The section payload</param>
+        /// <param name="sectionId">The section identifier</param>
+        /// <param name="configKey">The configuration key</param>
+        /// <param name="defaultValue">Default value if not found</param>
+        /// <returns>The effective decimal configuration value</returns>
+        public static decimal GetDecimalConfig(this HomeScreenSectionPayload payload, string sectionId, string configKey, decimal defaultValue = 0.0m)
+        {
+            return payload.GetEffectivePluginConfiguration<decimal>(sectionId, configKey, defaultValue);
+        }
+    }
+}

--- a/src/Jellyfin.Plugin.HomeScreenSections/Helpers/PluginConfigurationHelper.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Helpers/PluginConfigurationHelper.cs
@@ -1,0 +1,130 @@
+using Jellyfin.Plugin.HomeScreenSections.Configuration;
+
+namespace Jellyfin.Plugin.HomeScreenSections.Helpers
+{
+    /// <summary>
+    /// Helper class for external plugins to easily create configuration options
+    /// </summary>
+    public static class PluginConfigurationHelper
+    {
+        /// <summary>
+        /// Creates a checkbox configuration option
+        /// </summary>
+        /// <param name="key">Unique identifier for the configuration</param>
+        /// <param name="name">Display name shown in UI</param>
+        /// <param name="description">Help text describing the option</param>
+        /// <param name="defaultValue">Default checkbox state</param>
+        /// <param name="userOverridable">Whether this option can potentially be overridden by users (subject to admin permission)</param>
+        /// <param name="isAdvanced">Whether this is an advanced option that should be hidden by default</param>
+        /// <returns>Configuration option for a checkbox</returns>
+        public static PluginConfigurationOption CreateCheckbox(string key, string name, string description, bool defaultValue = false, bool userOverridable = true, bool isAdvanced = false)
+        {
+            return new PluginConfigurationOption
+            {
+                Key = key,
+                Name = name,
+                Description = description,
+                Type = PluginConfigurationType.Checkbox,
+                DefaultValue = defaultValue,
+                AllowUserOverride = userOverridable,
+                IsAdvanced = isAdvanced
+            };
+        }
+
+        /// <summary>
+        /// Creates a dropdown configuration option
+        /// </summary>
+        /// <param name="key">Unique identifier for the configuration</param>
+        /// <param name="name">Display name shown in UI</param>
+        /// <param name="description">Help text describing the option</param>
+        /// <param name="options">Array of option values</param>
+        /// <param name="labels">Array of human-readable labels (optional, uses options if null)</param>
+        /// <param name="defaultValue">Default selected option</param>
+        /// <param name="userOverridable">Whether this option can potentially be overridden by users (subject to admin permission)</param>
+        /// <param name="isAdvanced">Whether this is an advanced option that should be hidden by default</param>
+        /// <returns>Configuration option for a dropdown</returns>
+        public static PluginConfigurationOption CreateDropdown(string key, string name, string description, string[] options, string[]? labels = null, string? defaultValue = null, bool userOverridable = true, bool isAdvanced = false)
+        {
+            return new PluginConfigurationOption
+            {
+                Key = key,
+                Name = name,
+                Description = description,
+                Type = PluginConfigurationType.Dropdown,
+                DropdownOptions = options,
+                DropdownLabels = labels ?? options,
+                DefaultValue = defaultValue ?? options.FirstOrDefault(),
+                AllowUserOverride = userOverridable,
+                IsAdvanced = isAdvanced
+            };
+        }
+
+        /// <summary>
+        /// Creates a text box configuration option
+        /// </summary>
+        /// <param name="key">Unique identifier for the configuration</param>
+        /// <param name="name">Display name shown in UI</param>
+        /// <param name="description">Help text describing the option</param>
+        /// <param name="defaultValue">Default text value</param>
+        /// <param name="userOverridable">Whether this option can potentially be overridden by users (subject to admin permission)</param>
+        /// <param name="isAdvanced">Whether this is an advanced option that should be hidden by default</param>
+        /// <param name="placeholder">Placeholder text for the input</param>
+        /// <param name="minLength">Minimum allowed length</param>
+        /// <param name="maxLength">Maximum allowed length</param>
+        /// <param name="pattern">Regex pattern for validation</param>
+        /// <param name="validationMessage">Custom validation error message</param>
+        /// <returns>Configuration option for a text box</returns>
+        public static PluginConfigurationOption CreateTextBox(string key, string name, string description, string defaultValue = "", bool userOverridable = true, bool isAdvanced = false, string? placeholder = null, int? minLength = null, int? maxLength = null, string? pattern = null, string? validationMessage = null)
+        {
+            return new PluginConfigurationOption
+            {
+                Key = key,
+                Name = name,
+                Description = description,
+                Type = PluginConfigurationType.TextBox,
+                DefaultValue = defaultValue,
+                AllowUserOverride = userOverridable,
+                IsAdvanced = isAdvanced,
+                Placeholder = placeholder,
+                MinLength = minLength,
+                MaxLength = maxLength,
+                Pattern = pattern,
+                ValidationMessage = validationMessage
+            };
+        }
+
+        /// <summary>
+        /// Creates a number box configuration option
+        /// </summary>
+        /// <param name="key">Unique identifier for the configuration</param>
+        /// <param name="name">Display name shown in UI</param>
+        /// <param name="description">Help text describing the option</param>
+        /// <param name="defaultValue">Default numeric value</param>
+        /// <param name="userOverridable">Whether this option can potentially be overridden by users (subject to admin permission)</param>
+        /// <param name="isAdvanced">Whether this is an advanced option that should be hidden by default</param>
+        /// <param name="placeholder">Placeholder text for the input</param>
+        /// <param name="minValue">Minimum allowed value</param>
+        /// <param name="maxValue">Maximum allowed value</param>
+        /// <param name="step">Step increment for the input</param>
+        /// <param name="validationMessage">Custom validation error message</param>
+        /// <returns>Configuration option for a number box</returns>
+        public static PluginConfigurationOption CreateNumberBox(string key, string name, string description, double defaultValue = 0, bool userOverridable = true, bool isAdvanced = false, string? placeholder = null, double? minValue = null, double? maxValue = null, double? step = null, string? validationMessage = null)
+        {
+            return new PluginConfigurationOption
+            {
+                Key = key,
+                Name = name,
+                Description = description,
+                Type = PluginConfigurationType.NumberBox,
+                DefaultValue = defaultValue,
+                AllowUserOverride = userOverridable,
+                IsAdvanced = isAdvanced,
+                Placeholder = placeholder,
+                MinValue = minValue,
+                MaxValue = maxValue,
+                Step = step,
+                ValidationMessage = validationMessage
+            };
+        }
+    }
+}

--- a/src/Jellyfin.Plugin.HomeScreenSections/Helpers/TransformationPatches.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Helpers/TransformationPatches.cs
@@ -28,6 +28,11 @@ namespace Jellyfin.Plugin.HomeScreenSections.Helpers
 
         public static string IndexHtml(PatchRequestPayload content)
         {
+            if (!IsHomePage(content.Contents))
+            {
+                return content.Contents;
+            }
+
             NetworkConfiguration networkConfiguration = HomeScreenSectionsPlugin.Instance.ServerConfigurationManager.GetNetworkConfiguration();
 
             string rootPath = "";
@@ -42,6 +47,19 @@ namespace Jellyfin.Plugin.HomeScreenSections.Helpers
             return content.Contents!
                 .Replace("</head>", $"{replacementText0}</head>")
                 .Replace("</body>", $"{replacementText1}</body>");
+        }
+
+        private static bool IsHomePage(string? content)
+        {
+            if (string.IsNullOrEmpty(content))
+                return false;
+
+            bool hasIndexPageId = content.Contains("id=\"indexPage\"");
+            bool hasHomePageClass = content.Contains("class=\"page homePage");
+            bool hasSectionsDiv = content.Contains("<div class=\"sections\"></div>");
+            bool hasPageRole = content.Contains("data-role=\"page\"");
+            
+            return hasIndexPageId && hasHomePageClass && hasSectionsDiv && hasPageRole;
         }
     }
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/HomeScreenManager.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/HomeScreenManager.cs
@@ -163,7 +163,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen
 
             if (settings != null)
             {
-                IEnumerable<SectionSettings> forcedSectionSettings = HomeScreenSectionsPlugin.Instance.Configuration.SectionSettings.Where(x => !x.AllowUserOverride);
+                IEnumerable<SectionSettings> forcedSectionSettings = HomeScreenSectionsPlugin.Instance.Configuration.SectionSettings.Where(x => 
+                    x.UserOverrideSettings?.FirstOrDefault(u => u.Item == UserOverrideItem.EnableDisableSection)?.AllowUserOverride == false);
 
                 foreach (SectionSettings sectionSettings in forcedSectionSettings)
                 {
@@ -177,6 +178,9 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen
                     }
                 }
             }
+
+            // Sync SectionSettings from EnabledSections
+            settings?.SyncSectionSettings();
             
             return settings;
         }

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/BecauseYouWatchedSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/BecauseYouWatchedSection.cs
@@ -1,6 +1,7 @@
 ﻿using Jellyfin.Data.Entities;
 using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.HomeScreenSections.Configuration;
+using Jellyfin.Plugin.HomeScreenSections.Helpers;
 using Jellyfin.Plugin.HomeScreenSections.Library;
 using Jellyfin.Plugin.HomeScreenSections.Model.Dto;
 using MediaBrowser.Controller.Collections;
@@ -116,6 +117,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
 
 		public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload, IQueryCollection queryCollection)
 		{
+			bool showPlayedItems = payload.GetEffectivePluginConfiguration<bool>(Section ?? string.Empty, "supportsShowPlayedItems", false);
 			User user = UserManager.GetUserById(payload.UserId)!;
 			
 			DtoOptions? dtoOptions = new DtoOptions
@@ -146,7 +148,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
 				IsMovie = true,
 				SimilarTo = item,
 				User = user,
-				IsPlayed = false, // Maybe make this configuable but this is the preferred default behaviour.
+				IsPlayed = showPlayedItems,
 				EnableGroupByMetadataKey = true,
 				DtoOptions = dtoOptions
 			});
@@ -165,6 +167,27 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
 				Limit = Limit ?? 1,
 				OriginalPayload = OriginalPayload,
 				ViewMode = SectionViewMode.Landscape
+			};
+		}
+
+		/// <summary>
+		/// Get configuration options for this section
+		/// </summary>
+		/// <returns>Collection of configuration options</returns>
+		public virtual IEnumerable<PluginConfigurationOption> GetConfigurationOptions()
+		{
+			return new[]
+			{
+				new PluginConfigurationOption
+				{
+					Key = "supportsShowPlayedItems",
+                    Name = "Enable Rewatching",
+                    Description = "Enable showing already watched episodes",
+					Type = PluginConfigurationType.Checkbox,
+					AllowUserOverride = true,
+					IsAdvanced = false,
+					DefaultValue = false
+				}
 			};
 		}
 	}

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/ContinueWatchingSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/ContinueWatchingSection.cs
@@ -139,5 +139,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
                 AllowViewModeChange = false
             };
         }
+
+		public virtual IEnumerable<PluginConfigurationOption> GetConfigurationOptions() => Enumerable.Empty<PluginConfigurationOption>();
     }
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/LatestMoviesSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/LatestMoviesSection.cs
@@ -21,7 +21,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
         
         public int? Limit => 1;
 
-        public string? Route { get; set; } = null;
+        public string? Route => "movies";
         
         public string? AdditionalData { get; set; }
         
@@ -64,32 +64,60 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
             
             User? user = m_userManager.GetUserById(payload.UserId);
 
-            Folder? movieFolder = m_libraryManager.GetUserRootFolder()
-                .GetChildren(user, true)
-                .OfType<Folder>()
-                .FirstOrDefault(x => (x as ICollectionFolder)?.CollectionType == CollectionType.movies);
-
-            QueryResult<BaseItem>? latestMovies = movieFolder?.GetItems(new InternalItemsQuery
+            List<BaseItem> latestMovies = m_libraryManager.GetItemList(new InternalItemsQuery(user)
             {
                 IncludeItemTypes = new[]
                 {
                     BaseItemKind.Movie
                 },
                 Limit = 16,
-                User = user,
                 OrderBy = new[]
                 {
                     (ItemSortBy.PremiereDate, SortOrder.Descending)
                 }
             });
 
-            return new QueryResult<BaseItemDto>(Array.ConvertAll(latestMovies?.Items.ToArray() ?? Array.Empty<BaseItem>(),
+            return new QueryResult<BaseItemDto>(Array.ConvertAll(latestMovies.ToArray(),
                 i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)));
         }
 
         public IHomeScreenSection CreateInstance(Guid? userId, IEnumerable<IHomeScreenSection>? otherInstances = null)
         {
-            return this;
+            User? user = m_userManager.GetUserById(userId ?? Guid.Empty);
+
+            BaseItemDto? originalPayload = null;
+            
+            // Get only movie collection folders that the user can access
+            var movieFolders = m_libraryManager.GetUserRootFolder()
+                .GetChildren(user, true)
+                .OfType<Folder>()
+                .Where(x => (x as ICollectionFolder)?.CollectionType == CollectionType.movies)
+                .ToArray();
+            
+            // Check if there's a configured default library, otherwise use first available
+            var config = HomeScreenSectionsPlugin.Instance?.Configuration;
+            var folder = !string.IsNullOrEmpty(config?.DefaultMoviesLibraryId)
+                ? movieFolders.FirstOrDefault(x => x.Id.ToString() == config.DefaultMoviesLibraryId)
+                : null;
+            
+            // Fall back to first movies library if no configured library found
+            folder ??= movieFolders.FirstOrDefault();
+            
+            if (folder != null)
+            {
+                DtoOptions dtoOptions = new DtoOptions();
+                dtoOptions.Fields =
+                    [..dtoOptions.Fields, ItemFields.PrimaryImageAspectRatio, ItemFields.DisplayPreferencesId];
+                
+                originalPayload = Array.ConvertAll(new[] { folder }, i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)).First();
+            }
+
+            return new LatestMoviesSection(m_userViewManager, m_userManager, m_libraryManager, m_dtoService)
+            {
+                DisplayText = DisplayText,
+                AdditionalData = AdditionalData,
+                OriginalPayload = originalPayload
+            };
         }
         
         public HomeScreenSectionInfo GetInfo()
@@ -105,5 +133,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
                 ViewMode = SectionViewMode.Landscape
             };
         }
+
+		public virtual IEnumerable<PluginConfigurationOption> GetConfigurationOptions() => Enumerable.Empty<PluginConfigurationOption>();
     }
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/LatestShowsSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/LatestShowsSection.cs
@@ -23,11 +23,11 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
         
         public int? Limit => 1;
         
-        public string? Route { get; }
+        public string? Route => "tvshows";
         
         public string? AdditionalData { get; set; }
         
-        public object? OriginalPayload { get; }
+        public object? OriginalPayload { get; set; } = null;
         
         private readonly IUserViewManager m_userViewManager;
         private readonly IUserManager m_userManager;
@@ -74,7 +74,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
                 IncludeItemTypes = new[] { BaseItemKind.Episode },
                 OrderBy = new[] { (ItemSortBy.PremiereDate, SortOrder.Descending) },
                 DtoOptions = new DtoOptions
-                    { Fields = new[] { ItemFields.SeriesPresentationUniqueKey }, EnableImages = false }
+                    { Fields = new[] { ItemFields.SeriesPresentationUniqueKey }, EnableImages = true }
             });
             
             List<BaseItem> series = episodes
@@ -93,7 +93,41 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
 
         public IHomeScreenSection CreateInstance(Guid? userId, IEnumerable<IHomeScreenSection>? otherInstances = null)
         {
-            return this;
+            User? user = m_userManager.GetUserById(userId ?? Guid.Empty);
+
+            BaseItemDto? originalPayload = null;
+            
+            // Get only TV show collection folders that the user can access
+            var tvShowFolders = m_libraryManager.GetUserRootFolder()
+                .GetChildren(user, true)
+                .OfType<Folder>()
+                .Where(x => (x as ICollectionFolder)?.CollectionType == CollectionType.tvshows)
+                .ToArray();
+            
+            // Check if there's a configured default library, otherwise use first available
+            var config = HomeScreenSectionsPlugin.Instance?.Configuration;
+            var folder = !string.IsNullOrEmpty(config?.DefaultTVShowsLibraryId)
+                ? tvShowFolders.FirstOrDefault(x => x.Id.ToString() == config.DefaultTVShowsLibraryId)
+                : null;
+            
+            // Fall back to first TV shows library if no configured library found
+            folder ??= tvShowFolders.FirstOrDefault();
+            
+            if (folder != null)
+            {
+                DtoOptions dtoOptions = new DtoOptions();
+                dtoOptions.Fields =
+                    [..dtoOptions.Fields, ItemFields.PrimaryImageAspectRatio, ItemFields.DisplayPreferencesId];
+                
+                originalPayload = Array.ConvertAll(new[] { folder }, i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)).First();
+            }
+
+            return new LatestShowsSection(m_userViewManager, m_userManager, m_libraryManager, m_tvSeriesManager, m_dtoService)
+            {
+                DisplayText = DisplayText,
+                AdditionalData = AdditionalData,
+                OriginalPayload = originalPayload
+            };
         }
         
         public HomeScreenSectionInfo GetInfo()
@@ -109,5 +143,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
                 ViewMode = SectionViewMode.Landscape
             };
         }
+
+		public virtual IEnumerable<PluginConfigurationOption> GetConfigurationOptions() => Enumerable.Empty<PluginConfigurationOption>();
     }
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/LiveTvSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/LiveTvSection.cs
@@ -86,5 +86,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
 				ViewMode = SectionViewMode.Landscape
 			};
 		}
+
+		public virtual IEnumerable<PluginConfigurationOption> GetConfigurationOptions() => Enumerable.Empty<PluginConfigurationOption>();
 	}
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/MyListSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/MyListSection.cs
@@ -1,11 +1,16 @@
-﻿using Jellyfin.Data.Entities;
+﻿using System;
+using System.Collections.Generic;
+using Jellyfin.Data.Entities;
+using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.HomeScreenSections.Configuration;
+using Jellyfin.Plugin.HomeScreenSections.Helpers;
 using Jellyfin.Plugin.HomeScreenSections.Library;
 using Jellyfin.Plugin.HomeScreenSections.Model.Dto;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Playlists;
+using MediaBrowser.Model.Configuration;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Querying;
@@ -21,11 +26,11 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
 
 		public int? Limit => 1;
 
-		public string? Route => null;
+		public string? Route { get; set; } = null;
 
 		public string? AdditionalData { get; set; }
 
-		public object? OriginalPayload => null;
+		public object? OriginalPayload { get; set; } = null;
 		
 		private IUserManager UserManager { get; set; }
 
@@ -40,48 +45,140 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
 			PlaylistManager = playlistManager;
 		}
 
-		public IHomeScreenSection CreateInstance(Guid? userId, IEnumerable<IHomeScreenSection>? otherInstances = null)
+	public IHomeScreenSection CreateInstance(Guid? userId, IEnumerable<IHomeScreenSection>? otherInstances = null)
+	{
+		var (displayName, playlistId) = GetUserPlaylistInfo(userId);
+		
+		// Check for custom display name configuration - this would need to be passed from the calling context
+		// For now, we'll use the playlist name or default to "My List"
+		string finalDisplayName = !string.IsNullOrEmpty(displayName) ? displayName : "My List";
+		
+		// If user has a playlist, route to the specific playlist details
+		if (!string.IsNullOrEmpty(playlistId))
 		{
-			return this;
-		}
-
-		public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload, IQueryCollection queryCollection)
-		{
-			DtoOptions? dtoOptions = new DtoOptions
+			return new MyListSection(UserManager, DtoService, PlaylistManager)
 			{
-				Fields = new List<ItemFields>
-				{
-					ItemFields.PrimaryImageAspectRatio
-				},
-				ImageTypeLimit = 1,
-				ImageTypes = new List<ImageType>
-				{
-					ImageType.Thumb,
-					ImageType.Backdrop,
-					ImageType.Primary,
-				}
+				DisplayText = finalDisplayName,
+				Route = "details",
+				OriginalPayload = new { Id = playlistId, Type = "Playlist" }
 			};
-
-			User user = UserManager.GetUserById(payload.UserId)!;
-
-			IEnumerable<Playlist> playlists = PlaylistManager.GetPlaylists(user.Id);
-			Playlist? myListPlaylist = playlists.FirstOrDefault(x => x.Name == "My List");
-
-			List<BaseItem> results = new List<BaseItem>();
-
-			if (myListPlaylist != null)
-			{
-				results.AddRange(myListPlaylist.GetChildren(user, true, new InternalItemsQuery(user)
-				{
-					IsAiring = true
-				}));
-			}
-
-			QueryResult<BaseItemDto>? result = new QueryResult<BaseItemDto>(DtoService.GetBaseItemDtos(results, dtoOptions, user));
-
-			return result;
 		}
 		
+		// If no playlist, use simple list route to playlists library
+		return new MyListSection(UserManager, DtoService, PlaylistManager)
+		{
+			DisplayText = finalDisplayName,
+			Route = "list"
+		};
+	}	private (string displayName, string? playlistId) GetUserPlaylistInfo(Guid? userId)
+	{
+		if (userId == null) return ("My List", null);
+		
+		var myListPlaylist = PlaylistManager.GetPlaylists(userId.Value)
+			.FirstOrDefault(x => x.Name == "My List");
+		
+		if (myListPlaylist != null && myListPlaylist.Id != Guid.Empty)
+		{
+			return (myListPlaylist.Name, myListPlaylist.Id.ToString());
+		}
+		
+		return ("My List", null);
+	}
+
+	/// <summary>
+	/// Creates a placeholder BaseItemDto for empty states that links to the playlists library
+	/// </summary>
+	private BaseItemDto CreatePlaceholderItem(User user, string name, string overview)
+	{
+		// Get the playlists folder so the placeholder can link to it
+		var playlistsFolder = PlaylistManager.GetPlaylistsFolder(user.Id);
+		
+		return new BaseItemDto
+		{
+			Name = name,
+			Overview = overview,
+			Id = playlistsFolder?.Id ?? Guid.Empty, // Use playlists folder ID to make it clickable
+			Type = BaseItemKind.PlaylistsFolder,
+			ServerId = user.Id.ToString("N"), // Remove hyphens from GUID
+			IsFolder = true, // Make it clickable to navigate to playlists library
+			ImageTags = new Dictionary<ImageType, string>(),
+			BackdropImageTags = Array.Empty<string>(),
+			ScreenshotImageTags = Array.Empty<string>(),
+			PrimaryImageAspectRatio = 1.0,
+			// Set the correct parent ID for navigation
+			ParentId = playlistsFolder?.GetParent()?.Id ?? Guid.Empty,
+			// Make it clear this is a placeholder by setting some distinctive properties
+			LockedFields = Array.Empty<MetadataField>(),
+			LockData = false,
+			// Ensure proper collection type for navigation
+			CollectionType = CollectionType.playlists
+		};
+	}
+
+	public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload, IQueryCollection queryCollection)
+	{
+		bool showPlayedItems = payload.GetEffectivePluginConfiguration<bool>(Section ?? string.Empty, "supportsShowPlayedItems", true);
+		bool showPlaceholderWhenEmpty = payload.GetEffectivePluginConfiguration<bool>(Section ?? string.Empty, "showPlaceholderWhenEmpty", false);
+		
+		DtoOptions? dtoOptions = new DtoOptions
+		{
+			Fields = new List<ItemFields>
+			{
+				ItemFields.PrimaryImageAspectRatio
+			},
+			ImageTypeLimit = 1,
+			ImageTypes = new List<ImageType>
+			{
+				ImageType.Thumb,
+				ImageType.Backdrop,
+				ImageType.Primary,
+			}
+		};
+
+		User user = UserManager.GetUserById(payload.UserId)!;
+
+		IEnumerable<Playlist> playlists = PlaylistManager.GetPlaylists(user.Id);
+		Playlist? myListPlaylist = playlists.FirstOrDefault(x => x.Name == "My List");
+
+		List<BaseItem> results = new List<BaseItem>();
+
+		if (myListPlaylist != null)
+		{
+			results.AddRange(myListPlaylist.GetChildren(user, true, new InternalItemsQuery(user)
+			{
+				IsAiring = true
+			}));
+		}
+
+		// Filter out played items if the setting is disabled
+		if (!showPlayedItems)
+		{
+			results = results.Where(item => !item.IsPlayed(user)).ToList();
+		}
+
+		// Handle empty playlist scenarios
+		bool isPlaylistEmpty = myListPlaylist == null || !results.Any();
+		
+		if (isPlaylistEmpty)
+		{
+			if (showPlaceholderWhenEmpty)
+			{
+				// Show a placeholder item to indicate the section exists but is empty
+				var placeholderItem = CreatePlaceholderItem(user, "Your My List is empty", "Your My List is empty");
+				return new QueryResult<BaseItemDto>(new[] { placeholderItem });
+			}
+			else
+			{
+				// Hide the section when empty
+				return new QueryResult<BaseItemDto>();
+			}
+		}
+
+		QueryResult<BaseItemDto>? result = new QueryResult<BaseItemDto>(DtoService.GetBaseItemDtos(results, dtoOptions, user));
+
+		return result;
+	}
+
 		public HomeScreenSectionInfo GetInfo()
 		{
 			return new HomeScreenSectionInfo
@@ -93,6 +190,59 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
 				Limit = Limit ?? 1,
 				OriginalPayload = OriginalPayload,
 				ViewMode = SectionViewMode.Landscape
+			};
+		}
+
+		/// <summary>
+		/// Get configuration options for this section
+		/// </summary>
+		/// <returns>Collection of configuration options</returns>
+		public virtual IEnumerable<PluginConfigurationOption> GetConfigurationOptions()
+		{
+			return new[]
+			{
+				new PluginConfigurationOption
+				{
+					Key = "supportsShowPlayedItems",
+                    Name = "Enable Rewatching",
+                    Description = "Enable showing already watched episodes (note: this option will not remove items from My List, it only affects visibility)",
+					Type = PluginConfigurationType.Checkbox,
+					AllowUserOverride = true,
+					IsAdvanced = false,
+					DefaultValue = true
+				},
+				new PluginConfigurationOption
+				{
+					Key = "showPlaceholderWhenEmpty",
+					Name = "Show Placeholder When Empty",
+					Description = "Show a placeholder item when My List is empty instead of hiding the section",
+					Type = PluginConfigurationType.Checkbox,
+					AllowUserOverride = true,
+					IsAdvanced = true,
+					DefaultValue = false
+				},
+				new PluginConfigurationOption
+				{
+					Key = "testTextBox",
+					Name = "Test Text Box",
+					Description = "This is a test text box for advanced configuration",
+					Type = PluginConfigurationType.TextBox,
+					AllowUserOverride = true,
+					IsAdvanced = true,
+					DefaultValue = "Default text value"
+				},
+				new PluginConfigurationOption
+				{
+					Key = "testNumberBox",
+					Name = "Test Number Box",
+					Description = "This is a test number box with min/max values",
+					Type = PluginConfigurationType.NumberBox,
+					AllowUserOverride = true,
+					IsAdvanced = true,
+					DefaultValue = 10,
+					MinValue = 1,
+					MaxValue = 100
+				}
 			};
 		}
 	}

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/MyMediaSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/MyMediaSection.cs
@@ -106,5 +106,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
                 AllowViewModeChange = false
             };
         }
+
+		public virtual IEnumerable<PluginConfigurationOption> GetConfigurationOptions() => Enumerable.Empty<PluginConfigurationOption>();
     }
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/NextUpSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/NextUpSection.cs
@@ -146,5 +146,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
                 ViewMode = SectionViewMode.Landscape
             };
         }
+
+		public virtual IEnumerable<PluginConfigurationOption> GetConfigurationOptions() => Enumerable.Empty<PluginConfigurationOption>();
     }
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/PluginDefinedSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/PluginDefinedSection.cs
@@ -1,4 +1,5 @@
 ﻿using Jellyfin.Plugin.HomeScreenSections.Configuration;
+using Jellyfin.Plugin.HomeScreenSections.Helpers;
 using Jellyfin.Plugin.HomeScreenSections.Library;
 using Jellyfin.Plugin.HomeScreenSections.Model.Dto;
 using MediaBrowser.Model.Dto;
@@ -21,13 +22,16 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
         
         public required GetResultsDelegate OnGetResults { get; set; }
         
-        public PluginDefinedSection(string sectionUuid, string displayText, string? route = null, string? additionalData = null)
+        private readonly List<PluginConfigurationOption>? _configurationOptions;
+        
+        public PluginDefinedSection(string sectionUuid, string displayText, string? route = null, string? additionalData = null, List<PluginConfigurationOption>? configurationOptions = null)
         {
             Section = sectionUuid;
             DisplayText = displayText;
             Limit = 1;
             Route = route;
             AdditionalData = additionalData;
+            _configurationOptions = configurationOptions;
         }
         
         public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload, IQueryCollection queryCollection)
@@ -52,6 +56,16 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
                 OriginalPayload = OriginalPayload,
                 ViewMode = SectionViewMode.Landscape
             };
+        }
+
+        /// <summary>
+        /// Get configuration options for this section
+        /// </summary>
+        /// <returns>Collection of configuration options</returns>
+        public virtual IEnumerable<PluginConfigurationOption> GetConfigurationOptions()
+        {
+            // Return custom configuration options if provided, otherwise return empty collection
+            return _configurationOptions ?? Enumerable.Empty<PluginConfigurationOption>();
         }
     }
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/RecentlyAddedMoviesSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/RecentlyAddedMoviesSection.cs
@@ -80,44 +80,22 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
                 ImageType.Primary,
             };
 
-            MyMediaSection myMedia = new MyMediaSection(m_userViewManager, m_userManager, m_dtoService);
-            QueryResult<BaseItemDto> media = myMedia.GetResults(payload, queryCollection);
-
-            Guid parentId = media.Items.FirstOrDefault(x => x.Name == payload.AdditionalData)?.Id ?? Guid.Empty;
-
-            List<Tuple<BaseItem, List<BaseItem>>>? list = m_userViewManager.GetLatestItems(
-                new LatestItemsQuery
-                {
-                    GroupItems = false,
-                    Limit = 16,
-                    ParentId = parentId,
-                    User = user,
-                    IncludeItemTypes = new BaseItemKind[]
-                    {
-                        BaseItemKind.Movie
-                    }
-                },
-                dtoOptions);
-
-            IEnumerable<BaseItemDto>? dtos = list.Select(i =>
+            List<BaseItem> recentlyAddedMovies = m_libraryManager.GetItemList(new InternalItemsQuery(user)
             {
-                BaseItem? item = i.Item2[0];
-                int childCount = 0;
-
-                if (i.Item1 != null && (i.Item2.Count > 1 || i.Item1 is MusicAlbum))
+                IncludeItemTypes = new[]
                 {
-                    item = i.Item1;
-                    childCount = i.Item2.Count;
-                }
-
-                BaseItemDto? dto = m_dtoService.GetBaseItemDto(item, dtoOptions, user);
-
-                dto.ChildCount = childCount;
-
-                return dto;
+                    BaseItemKind.Movie
+                },
+                Limit = 16,
+                OrderBy = new[]
+                {
+                    (ItemSortBy.DateCreated, SortOrder.Descending)
+                },
+                DtoOptions = dtoOptions
             });
 
-            return new QueryResult<BaseItemDto>(dtos.ToList());
+            return new QueryResult<BaseItemDto>(Array.ConvertAll(recentlyAddedMovies.ToArray(),
+                i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)));
         }
 
         /// <inheritdoc/>
@@ -125,14 +103,24 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
         {
             User? user = m_userManager.GetUserById(userId ?? Guid.Empty);
 
-            Folder? folder = m_libraryManager.GetUserRootFolder()
+            BaseItemDto? originalPayload = null;
+            
+            // Get only movie collection folders that the user can access
+            var movieFolders = m_libraryManager.GetUserRootFolder()
                 .GetChildren(user, true)
                 .OfType<Folder>()
-                .Select(x => x as ICollectionFolder)
-                .Where(x => x != null)
-                .FirstOrDefault(x => x!.CollectionType == CollectionType.movies) as Folder;
-
-            BaseItemDto? originalPayload = null;
+                .Where(x => (x as ICollectionFolder)?.CollectionType == CollectionType.movies)
+                .ToArray();
+            
+            // Check if there's a configured default library, otherwise use first available
+            var config = HomeScreenSectionsPlugin.Instance?.Configuration;
+            var folder = !string.IsNullOrEmpty(config?.DefaultMoviesLibraryId)
+                ? movieFolders.FirstOrDefault(x => x.Id.ToString() == config.DefaultMoviesLibraryId)
+                : null;
+            
+            // Fall back to first movies library if no configured library found
+            folder ??= movieFolders.FirstOrDefault();
+            
             if (folder != null)
             {
                 DtoOptions dtoOptions = new DtoOptions();
@@ -163,5 +151,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
                 ViewMode = SectionViewMode.Landscape
             };
         }
+
+		public virtual IEnumerable<PluginConfigurationOption> GetConfigurationOptions() => Enumerable.Empty<PluginConfigurationOption>();
     }
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/RecentlyAddedShowsSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/RecentlyAddedShowsSection.cs
@@ -108,14 +108,24 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
         {
             User? user = m_userManager.GetUserById(userId ?? Guid.Empty);
 
-            Folder? folder = m_libraryManager.GetUserRootFolder()
+            BaseItemDto? originalPayload = null;
+            
+            // Get only TV show collection folders that the user can access
+            var tvShowFolders = m_libraryManager.GetUserRootFolder()
                 .GetChildren(user, true)
                 .OfType<Folder>()
-                .Select(x => x as ICollectionFolder)
-                .Where(x => x != null)
-                .FirstOrDefault(x => x!.CollectionType == CollectionType.tvshows) as Folder;
-
-            BaseItemDto? originalPayload = null;
+                .Where(x => (x as ICollectionFolder)?.CollectionType == CollectionType.tvshows)
+                .ToArray();
+            
+            // Check if there's a configured default library, otherwise use first available
+            var config = HomeScreenSectionsPlugin.Instance?.Configuration;
+            var folder = !string.IsNullOrEmpty(config?.DefaultTVShowsLibraryId)
+                ? tvShowFolders.FirstOrDefault(x => x.Id.ToString() == config.DefaultTVShowsLibraryId)
+                : null;
+            
+            // Fall back to first TV shows library if no configured library found
+            folder ??= tvShowFolders.FirstOrDefault();
+            
             if (folder != null)
             {
                 DtoOptions dtoOptions = new DtoOptions();
@@ -146,5 +156,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
                 ViewMode = SectionViewMode.Landscape
             };
         }
+
+		public virtual IEnumerable<PluginConfigurationOption> GetConfigurationOptions() => Enumerable.Empty<PluginConfigurationOption>();
     }
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/TopTenSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/TopTenSection.cs
@@ -123,4 +123,6 @@ public class TopTenSection : IHomeScreenSection
             AllowViewModeChange = false
         };
     }
+
+		public virtual IEnumerable<PluginConfigurationOption> GetConfigurationOptions() => Enumerable.Empty<PluginConfigurationOption>();
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/WatchAgainSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/WatchAgainSection.cs
@@ -182,5 +182,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
 				ViewMode = SectionViewMode.Landscape
 			};
 		}
+
+		public virtual IEnumerable<PluginConfigurationOption> GetConfigurationOptions() => Enumerable.Empty<PluginConfigurationOption>();
 	}
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/Model/Dto/HomeScreenSectionPayload.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Model/Dto/HomeScreenSectionPayload.cs
@@ -1,3 +1,6 @@
+using Jellyfin.Plugin.HomeScreenSections.Configuration;
+using Jellyfin.Plugin.HomeScreenSections.Library;
+
 namespace Jellyfin.Plugin.HomeScreenSections.Model.Dto
 {
     
@@ -15,5 +18,95 @@ namespace Jellyfin.Plugin.HomeScreenSections.Model.Dto
         
         
         public string? AdditionalData { get; set; }
+
+        /// <summary>
+        /// User-specific settings for modular home sections.
+        /// </summary>
+        public ModularHomeUserSettings? UserSettings { get; set; }
+        
+        /// <summary>
+        /// Cache for plugin configuration values to avoid repeated lookups during a single request
+        /// </summary>
+        private readonly Dictionary<string, object?> _pluginConfigCache = new Dictionary<string, object?>();
+        
+        /// <summary>
+        /// Gets the effective value for a plugin-defined configuration option,
+        /// considering both admin configuration and user preferences.
+        /// Uses caching to avoid repeated lookups during a single request.
+        /// </summary>
+        /// <param name="sectionId">The section ID to check.</param>
+        /// <param name="configurationKey">The configuration key to retrieve.</param>
+        /// <param name="defaultValue">The default value if no configuration is found.</param>
+        /// <returns>The effective configuration value.</returns>
+        public T GetEffectivePluginConfiguration<T>(string sectionId, string configurationKey, T defaultValue = default(T)!)
+        {
+            if (string.IsNullOrEmpty(sectionId) || string.IsNullOrEmpty(configurationKey))
+                return defaultValue;
+            
+            // Create cache key combining section and config key
+            var cacheKey = $"{sectionId}:{configurationKey}";
+            
+            // Check cache first
+            if (_pluginConfigCache.TryGetValue(cacheKey, out var cachedValue))
+            {
+                try
+                {
+                    return (T)Convert.ChangeType(cachedValue, typeof(T))!;
+                }
+                catch
+                {
+                    return defaultValue;
+                }
+            }
+            
+            // Cache miss - perform lookup
+            object? effectiveValue = null;
+            
+            var adminConfig = HomeScreenSectionsPlugin.Instance?.Configuration;
+            var sectionSettings = adminConfig?.SectionSettings?.FirstOrDefault(s => s.SectionId == sectionId);
+            
+            if (sectionSettings != null)
+            {
+                // Check if this configuration option allows user override
+                // For now, default to allowing override - this could be enhanced to check plugin definition
+                var allowUserOverride = true;
+                
+                if (allowUserOverride && UserSettings != null)
+                {
+                    // Check user's settings first
+                    var userSectionSettings = UserSettings.GetSectionSettings(sectionId);
+                    if (userSectionSettings.PluginConfigurations.TryGetValue(configurationKey, out var userValue) && userValue != null)
+                    {
+                        effectiveValue = userValue;
+                    }
+                }
+                
+                // Fall back to admin's setting if no user override
+                if (effectiveValue == null)
+                {
+                    var adminValue = sectionSettings.GetPluginConfiguration<T>(configurationKey, default);
+                    if (adminValue != null && !adminValue.Equals(default(T)))
+                    {
+                        effectiveValue = adminValue;
+                    }
+                }
+            }
+            
+            // Use default if no configuration found
+            effectiveValue ??= defaultValue;
+            
+            // Cache the result
+            _pluginConfigCache[cacheKey] = effectiveValue;
+            
+            // Convert and return
+            try
+            {
+                return (T)Convert.ChangeType(effectiveValue, typeof(T))!;
+            }
+            catch
+            {
+                return defaultValue;
+            }
+        }
     }
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/Model/SectionRegisterPayload.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Model/SectionRegisterPayload.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Serialization;
+using Jellyfin.Plugin.HomeScreenSections.Configuration;
 
 namespace Jellyfin.Plugin.HomeScreenSections.Model
 {
@@ -21,5 +22,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.Model
         
         [JsonPropertyName("resultsEndpoint")]
         public string? ResultsEndpoint { get; set; }
+        
+        [JsonPropertyName("configurationOptions")]
+        public List<PluginConfigurationOption>? ConfigurationOptions { get; set; }
     }
 }


### PR DESCRIPTION
Thanks for creating this plugin! This is the level of frontpage customization I have been wanting to see in Jellyfin for awhile, so I am really excited to have recently discovered this plugin, as well as your other related plugins.

This PR morphed a little bit and is now primarily a plugin-extensible custom configuration system allowing developers creating their own plugins to utilize and add their own admin and user set configuration options easily. In addition, that way all jellyfin-plugin-home-sections can live under one roof.

Example configuration option
```json
		{
			"Key": "ShowEmpty", // Unique key for this configuration option
			"Name": "Show When Empty", // Display name for admins/users
			"Description": "Display this section even when no items are available", // Help text
			"Type": "Checkbox", // Boolean configuration
			"AllowUserOverride": true, // Whether users can override this setting
			"DefaultValue": false, // Default value for this option
			"IsAdvanced": false // Whether this appears in advanced options only
		},
```

Currently all plugins support enable/disable and Custom Display Name without any plugin-side configuration. Both of these can be individually set to be user-configurable if allowed by the admin via per-setting-specific user override options. Any custom configuration can also support user-configuration if "AllowUserOverride" is set to true and if the Admin has that setting's user override enabled.

Custom configuration also supports an "isAdvanced" boolean with the idea that we could add an "advanced options" button somewhere on the new UI.

Other changes:
- **Respect User Homepage Setting**: Option to honor existing user homepage preferences (current behavior) instead of overriding them. default=true
- **My List Updates**: Header now links to a user's My List playlist, or playlist library. Supports admin-wide and/or user-wide name change, along with every other section. Supports an option to hide watched items (only hides, does not delete them from the playlist). TBD: Working on adding an option  to show a placeholder BaseItemDto in order to always show the My List section, even if there are no playlist items. Placeholder links to the user's playlists.


Old PR notes
<details>
This PR is aimed at tackling a few requested enhancements, with the goal of increased administrator and user customability. An issue with this PR is that the plugin configuration page now takes a few more mouse wheels to get to the bottom. Fortunately the horizontal configuration in https://github.com/IAmParadox27/jellyfin-plugin-home-sections/pull/57 seems like it will take care of that! 

Note: https://github.com/IAmParadox27/jellyfin-plugin-home-sections/pull/57 would need to be expanded to support the added default settings and user override settings. If https://github.com/n00bcodr would like to make those changes I look forward to seeing what they come up with! Otherwise I can make an attempt at it after that PR is pushed.


Main changes
- Can set custom display names for sections. [Available: all sections] (Issue: https://github.com/IAmParadox27/jellyfin-plugin-home-sections/issues/41, https://github.com/IAmParadox27/jellyfin-plugin-home-sections/issues/45)
- Can hide played items [Available: "My List", "Because You Watched"] (Issue: Partially https://github.com/IAmParadox27/jellyfin-plugin-home-sections/issues/43)
- User settings update with new granular administrator override settings
    - There is now a per-section "Allow User Override" to completely disallow all user overrides for that section
    - Each section now has a list of specific user overrides an administrator can allow / not allow for the items listed above.

Other
- "My List" now links to a user's "My List" playlist (Issue: https://github.com/IAmParadox27/jellyfin-plugin-home-sections/issues/42)

Plugin configuration
<img width="905" height="1042" alt="image" src="https://github.com/user-attachments/assets/3d34fac4-93a8-4380-8f97-1952a04fcc99" />

Plugin configuration - "Allow User Override" checkbox expands granular controls
<img width="845" height="1237" alt="image" src="https://github.com/user-attachments/assets/6013b01a-0bd6-4a89-a13d-63549ec992d0" />

User configuration will display allowed configurations
<img width="1551" height="1160" alt="image" src="https://github.com/user-attachments/assets/98ea752f-fd7d-4eb7-b78f-4ea98ccd4370" />

User configuration sections managed by the administrator
<img width="1677" height="1010" alt="image" src="https://github.com/user-attachments/assets/b7a80cd0-fd46-438d-b556-bd9fb99e8359" />
</details>
