### PR TITLE
feat: add music library support

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/PluginConfiguration.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/PluginConfiguration.cs
@@ -22,6 +22,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.Configuration
         
         public string? DefaultTVShowsLibraryId { get; set; } = "";
         
+        public string? DefaultMusicLibraryId { get; set; } = "";
+        
         public SectionSettings[] SectionSettings { get; set; } = Array.Empty<SectionSettings>();
     }
 

--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
@@ -93,6 +93,13 @@
                                     </select>
                                     <div class="fieldDescription">Select the specific TV shows library to use for navigation. Lists all underlying library folders (not grouped views).<br><strong>Requires Jellyfin restart to take effect.</strong></div>
                                 </div>
+                                <div class="inputContainer">
+                                    <label class="inputLabel inputLabelUnfocused" for="defaultMusicLibrary">Default Music Library</label>
+                                    <select is="emby-select" id="defaultMusicLibrary" class="emby-select-withcolor emby-select">
+                                        <option value="">Default</option>
+                                    </select>
+                                    <div class="fieldDescription">Select the specific music library to use for navigation. Lists all underlying library folders (not grouped views).<br><strong>Requires Jellyfin restart to take effect.</strong></div>
+                                </div>
                             </div>
                         </details>
                     </div>
@@ -236,12 +243,14 @@
                 window.ApiClient.getVirtualFolders().then(function (result) {
                     const moviesSelect = document.querySelector('#defaultMoviesLibrary');
                     const tvShowsSelect = document.querySelector('#defaultTVShowsLibrary');
+                    const musicSelect = document.querySelector('#defaultMusicLibrary');
 
                     moviesSelect.innerHTML = '<option value="">Default</option>';
                     tvShowsSelect.innerHTML = '<option value="">Default</option>';
+                    musicSelect.innerHTML = '<option value="">Default</option>';
 
                     result.forEach(function (folder) {
-                         if (folder.CollectionType === 'movies' || folder.CollectionType === 'tvshows') {
+                         if (folder.CollectionType === 'movies' || folder.CollectionType === 'tvshows' || folder.CollectionType === 'music') {
                              const option = document.createElement('option');
                             let folderId = folder.ItemId;
                             if (folderId && !folderId.includes('-')) {
@@ -252,6 +261,7 @@
 
                             if(folder.CollectionType === 'movies') moviesSelect.appendChild(option);
                             if(folder.CollectionType === 'tvshows') tvShowsSelect.appendChild(option);
+                            if(folder.CollectionType === 'music') musicSelect.appendChild(option);
                         }
                     });
                 }).catch(function (error) {
@@ -272,6 +282,7 @@
                     JellyseerrPreferredLanguages: document.querySelector('[data-id=txtJellyseerrPreferredLanguages]').value,
                     DefaultMoviesLibraryId: document.querySelector('#defaultMoviesLibrary').value,
                     DefaultTVShowsLibraryId: document.querySelector('#defaultTVShowsLibrary').value,
+                    DefaultMusicLibraryId: document.querySelector('#defaultMusicLibrary').value,
                     SectionSettings: []
                 };
 
@@ -312,6 +323,9 @@
                             }
                             if (config.DefaultTVShowsLibraryId) {
                                 document.querySelector('#defaultTVShowsLibrary').value = config.DefaultTVShowsLibraryId;
+                            }
+                            if (config.DefaultMusicLibraryId) {
+                                document.querySelector('#defaultMusicLibrary').value = config.DefaultMusicLibraryId;
                             }
                         }, 500);
 

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/HomeScreenManager.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/HomeScreenManager.cs
@@ -50,8 +50,11 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen
             RegisterResultsDelegate<NextUpSection>();
             RegisterResultsDelegate<RecentlyAddedMoviesSection>();
             RegisterResultsDelegate<RecentlyAddedShowsSection>();
+            RegisterResultsDelegate<RecentlyAddedAlbumsSection>();
+            RegisterResultsDelegate<RecentlyAddedArtistsSection>();
             RegisterResultsDelegate<LatestMoviesSection>();
             RegisterResultsDelegate<LatestShowsSection>();
+            RegisterResultsDelegate<LatestAlbumsSection>();
             RegisterResultsDelegate<BecauseYouWatchedSection>();
             RegisterResultsDelegate<LiveTvSection>();
             RegisterResultsDelegate<MyListSection>();

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/LatestAlbumsSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/LatestAlbumsSection.cs
@@ -1,0 +1,134 @@
+using Jellyfin.Plugin.HomeScreenSections.Configuration;
+using Jellyfin.Plugin.HomeScreenSections.Library;
+using Jellyfin.Plugin.HomeScreenSections.Model.Dto;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Http;
+
+namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
+{
+    public class LatestAlbumsSection : IHomeScreenSection
+    {
+        public string? Section => "LatestAlbums";
+        
+        public string? DisplayText { get; set; } = "Latest Albums";
+        
+        public int? Limit => 1;
+
+        public string? Route => "music";
+        
+        public string? AdditionalData { get; set; } = "albums";
+        
+        public object? OriginalPayload { get; set; } = null;
+        
+        private readonly IUserViewManager m_userViewManager;
+        private readonly IUserManager m_userManager;
+        private readonly ILibraryManager m_libraryManager;
+        private readonly IDtoService m_dtoService;
+
+        public LatestAlbumsSection(IUserViewManager userViewManager,
+            IUserManager userManager,
+            ILibraryManager libraryManager,
+            IDtoService dtoService)
+        {
+            m_userViewManager = userViewManager;
+            m_userManager = userManager;
+            m_libraryManager = libraryManager;
+            m_dtoService = dtoService;
+        }
+        
+
+        public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload, IQueryCollection queryCollection)
+        {
+            DtoOptions? dtoOptions = new DtoOptions
+            {
+                Fields = new List<ItemFields>
+                {
+                    ItemFields.PrimaryImageAspectRatio,
+                    ItemFields.Path
+                }
+            };
+
+            dtoOptions.ImageTypeLimit = 1;
+            dtoOptions.ImageTypes = new List<ImageType>
+            {
+                ImageType.Primary,
+                ImageType.Thumb,
+                ImageType.Backdrop,
+            };
+            
+            User? user = m_userManager.GetUserById(payload.UserId);
+
+            IReadOnlyList<BaseItem> latestAlbums = m_libraryManager.GetItemList(new InternalItemsQuery(user)
+            {
+                IncludeItemTypes = new[]
+                {
+                    BaseItemKind.MusicAlbum
+                },
+                Limit = 16,
+                OrderBy = new[]
+                {
+                    (ItemSortBy.PremiereDate, SortOrder.Descending)
+                }
+            });
+
+            return new QueryResult<BaseItemDto>(Array.ConvertAll(latestAlbums.ToArray(),
+                i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)));
+        }
+
+
+        public IHomeScreenSection CreateInstance(Guid? userId, IEnumerable<IHomeScreenSection>? otherInstances = null)
+        {
+            User? user = m_userManager.GetUserById(userId ?? Guid.Empty);
+
+            BaseItemDto? originalPayload = null;
+            
+            var musicFolders = m_libraryManager.GetUserRootFolder()
+                .GetChildren(user, true)
+                .OfType<Folder>()
+                .Where(x => (x as ICollectionFolder)?.CollectionType == CollectionType.music)
+                .ToArray();
+            
+            var config = HomeScreenSectionsPlugin.Instance?.Configuration;
+            var folder = !string.IsNullOrEmpty(config?.DefaultMusicLibraryId)
+                ? musicFolders.FirstOrDefault(x => x.Id.ToString() == config.DefaultMusicLibraryId)
+                : null;
+            
+            folder ??= musicFolders.FirstOrDefault();
+            
+            if (folder != null)
+            {
+                DtoOptions dtoOptions = new DtoOptions();
+                dtoOptions.Fields =
+                    [..dtoOptions.Fields, ItemFields.PrimaryImageAspectRatio, ItemFields.DisplayPreferencesId];
+                
+                originalPayload = Array.ConvertAll(new[] { folder }, i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)).First();
+            }
+
+            return new LatestAlbumsSection(m_userViewManager, m_userManager, m_libraryManager, m_dtoService)
+            {
+                DisplayText = DisplayText,
+                AdditionalData = AdditionalData,
+                OriginalPayload = originalPayload
+            };
+        }
+        
+        public HomeScreenSectionInfo GetInfo()
+        {
+            return new HomeScreenSectionInfo
+            {
+                Section = Section,
+                DisplayText = DisplayText,
+                AdditionalData = AdditionalData,
+                Route = Route,
+                Limit = Limit ?? 1,
+                OriginalPayload = OriginalPayload,
+                ViewMode = SectionViewMode.Square
+            };
+        }
+    }
+}

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/RecentlyAddedAlbumsSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/RecentlyAddedAlbumsSection.cs
@@ -1,0 +1,133 @@
+using Jellyfin.Plugin.HomeScreenSections.Configuration;
+using Jellyfin.Plugin.HomeScreenSections.Library;
+using Jellyfin.Plugin.HomeScreenSections.Model.Dto;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Http;
+
+namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
+{
+    public class RecentlyAddedAlbumsSection : IHomeScreenSection
+    {
+        public string? Section => "RecentlyAddedAlbums";
+
+        public string? DisplayText { get; set; } = "Recently Added Albums";
+
+        public int? Limit => 1;
+
+        public string? Route => "music";
+
+        public string? AdditionalData { get; set; } = "albums";
+
+        public object? OriginalPayload { get; set; } = null;
+        
+        private readonly IUserViewManager m_userViewManager;
+        private readonly IUserManager m_userManager;
+        private readonly ILibraryManager m_libraryManager;
+        private readonly IDtoService m_dtoService;
+
+        public RecentlyAddedAlbumsSection(IUserViewManager userViewManager,
+            IUserManager userManager,
+            ILibraryManager libraryManager,
+            IDtoService dtoService)
+        {
+            m_userViewManager = userViewManager;
+            m_userManager = userManager;
+            m_libraryManager = libraryManager;
+            m_dtoService = dtoService;
+        }
+
+        public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload, IQueryCollection queryCollection)
+        {
+            User? user = m_userManager.GetUserById(payload.UserId);
+
+            DtoOptions? dtoOptions = new DtoOptions
+            {
+                Fields = new List<ItemFields>
+                {
+                    ItemFields.PrimaryImageAspectRatio,
+                    ItemFields.Path
+                }
+            };
+
+            dtoOptions.ImageTypeLimit = 1;
+            dtoOptions.ImageTypes = new List<ImageType>
+            {
+                ImageType.Primary,
+                ImageType.Thumb,
+                ImageType.Backdrop,
+            };
+
+            IReadOnlyList<BaseItem> recentlyAddedAlbums = m_libraryManager.GetItemList(new InternalItemsQuery(user)
+            {
+                IncludeItemTypes = new[]
+                {
+                    BaseItemKind.MusicAlbum
+                },
+                Limit = 16,
+                OrderBy = new[]
+                {
+                    (ItemSortBy.DateCreated, SortOrder.Descending)
+                },
+                DtoOptions = dtoOptions
+            });
+
+            return new QueryResult<BaseItemDto>(Array.ConvertAll(recentlyAddedAlbums.ToArray(),
+                i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)));
+        }
+
+        public IHomeScreenSection CreateInstance(Guid? userId, IEnumerable<IHomeScreenSection>? otherInstances = null)
+        {
+            User? user = m_userManager.GetUserById(userId ?? Guid.Empty);
+
+            BaseItemDto? originalPayload = null;
+            
+            var musicFolders = m_libraryManager.GetUserRootFolder()
+                .GetChildren(user, true)
+                .OfType<Folder>()
+                .Where(x => (x as ICollectionFolder)?.CollectionType == CollectionType.music)
+                .ToArray();
+            
+            var config = HomeScreenSectionsPlugin.Instance?.Configuration;
+            var folder = !string.IsNullOrEmpty(config?.DefaultMusicLibraryId)
+                ? musicFolders.FirstOrDefault(x => x.Id.ToString() == config.DefaultMusicLibraryId)
+                : null;
+            
+            folder ??= musicFolders.FirstOrDefault();
+            
+            if (folder != null)
+            {
+                DtoOptions dtoOptions = new DtoOptions();
+                dtoOptions.Fields =
+                    [..dtoOptions.Fields, ItemFields.PrimaryImageAspectRatio, ItemFields.DisplayPreferencesId];
+
+                originalPayload = Array.ConvertAll(new[] { folder }, i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)).First();
+            }
+
+            return new RecentlyAddedAlbumsSection(m_userViewManager, m_userManager, m_libraryManager, m_dtoService)
+            {
+                AdditionalData = AdditionalData,
+                DisplayText = DisplayText,
+                OriginalPayload = originalPayload
+            };
+        }
+        
+        public HomeScreenSectionInfo GetInfo()
+        {
+            return new HomeScreenSectionInfo
+            {
+                Section = Section,
+                DisplayText = DisplayText,
+                AdditionalData = AdditionalData,
+                Route = Route,
+                Limit = Limit ?? 1,
+                OriginalPayload = OriginalPayload,
+                ViewMode = SectionViewMode.Square
+            };
+        }
+    }
+}

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/RecentlyAddedArtistsSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/RecentlyAddedArtistsSection.cs
@@ -1,0 +1,133 @@
+using Jellyfin.Plugin.HomeScreenSections.Configuration;
+using Jellyfin.Plugin.HomeScreenSections.Library;
+using Jellyfin.Plugin.HomeScreenSections.Model.Dto;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Http;
+
+namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
+{
+    public class RecentlyAddedArtistsSection : IHomeScreenSection
+    {
+        public string? Section => "RecentlyAddedArtists";
+
+        public string? DisplayText { get; set; } = "Recently Added Artists";
+
+        public int? Limit => 1;
+
+        public string? Route => "music";
+
+        public string? AdditionalData { get; set; } = "artists";
+
+        public object? OriginalPayload { get; set; } = null;
+        
+        private readonly IUserViewManager m_userViewManager;
+        private readonly IUserManager m_userManager;
+        private readonly ILibraryManager m_libraryManager;
+        private readonly IDtoService m_dtoService;
+
+        public RecentlyAddedArtistsSection(IUserViewManager userViewManager,
+            IUserManager userManager,
+            ILibraryManager libraryManager,
+            IDtoService dtoService)
+        {
+            m_userViewManager = userViewManager;
+            m_userManager = userManager;
+            m_libraryManager = libraryManager;
+            m_dtoService = dtoService;
+        }
+
+        public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload, IQueryCollection queryCollection)
+        {
+            User? user = m_userManager.GetUserById(payload.UserId);
+
+            DtoOptions? dtoOptions = new DtoOptions
+            {
+                Fields = new List<ItemFields>
+                {
+                    ItemFields.PrimaryImageAspectRatio,
+                    ItemFields.Path
+                }
+            };
+
+            dtoOptions.ImageTypeLimit = 1;
+            dtoOptions.ImageTypes = new List<ImageType>
+            {
+                ImageType.Primary,
+                ImageType.Thumb,
+                ImageType.Backdrop,
+            };
+
+            IReadOnlyList<BaseItem> recentlyAddedArtists = m_libraryManager.GetItemList(new InternalItemsQuery(user)
+            {
+                IncludeItemTypes = new[]
+                {
+                    BaseItemKind.MusicArtist
+                },
+                Limit = 16,
+                OrderBy = new[]
+                {
+                    (ItemSortBy.DateCreated, SortOrder.Descending)
+                },
+                DtoOptions = dtoOptions
+            });
+
+            return new QueryResult<BaseItemDto>(Array.ConvertAll(recentlyAddedArtists.ToArray(),
+                i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)));
+        }
+
+        public IHomeScreenSection CreateInstance(Guid? userId, IEnumerable<IHomeScreenSection>? otherInstances = null)
+        {
+            User? user = m_userManager.GetUserById(userId ?? Guid.Empty);
+
+            BaseItemDto? originalPayload = null;
+            
+            var musicFolders = m_libraryManager.GetUserRootFolder()
+                .GetChildren(user, true)
+                .OfType<Folder>()
+                .Where(x => (x as ICollectionFolder)?.CollectionType == CollectionType.music)
+                .ToArray();
+            
+            var config = HomeScreenSectionsPlugin.Instance?.Configuration;
+            var folder = !string.IsNullOrEmpty(config?.DefaultMusicLibraryId)
+                ? musicFolders.FirstOrDefault(x => x.Id.ToString() == config.DefaultMusicLibraryId)
+                : null;
+            
+            folder ??= musicFolders.FirstOrDefault();
+            
+            if (folder != null)
+            {
+                DtoOptions dtoOptions = new DtoOptions();
+                dtoOptions.Fields =
+                    [..dtoOptions.Fields, ItemFields.PrimaryImageAspectRatio, ItemFields.DisplayPreferencesId];
+
+                originalPayload = Array.ConvertAll(new[] { folder }, i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)).First();
+            }
+
+            return new RecentlyAddedArtistsSection(m_userViewManager, m_userManager, m_libraryManager, m_dtoService)
+            {
+                AdditionalData = AdditionalData,
+                DisplayText = DisplayText,
+                OriginalPayload = originalPayload
+            };
+        }
+        
+        public HomeScreenSectionInfo GetInfo()
+        {
+            return new HomeScreenSectionInfo
+            {
+                Section = Section,
+                DisplayText = DisplayText,
+                AdditionalData = AdditionalData,
+                Route = Route,
+                Limit = Limit ?? 1,
+                OriginalPayload = OriginalPayload,
+                ViewMode = SectionViewMode.Portrait
+            };
+        }
+    }
+}


### PR DESCRIPTION
closes https://features.iamparadox.dev/posts/6/add-section-for-music and half of https://github.com/IAmParadox27/jellyfin-plugin-home-sections/issues/13 :sweat_smile: i'll do the other half after this

adds 3 new sections:

### Recently Added Albums
<img width="2214" height="329" alt="image" src="https://github.com/user-attachments/assets/66aac0db-0c6a-4ce1-8e69-fb82bf2f7746" />

### Latest Albums
<img width="2207" height="314" alt="image" src="https://github.com/user-attachments/assets/f6a145d6-f4e8-4409-abf8-921d0fb4aada" />

### Recently Added Artists
<img width="2223" height="409" alt="image" src="https://github.com/user-attachments/assets/44b45ece-af83-40ff-aed0-bdd8464174db" />
