### PR TITLE
feat: add book library support

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/PluginConfiguration.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/PluginConfiguration.cs
@@ -24,6 +24,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.Configuration
         
         public string? DefaultMusicLibraryId { get; set; } = "";
         
+        public string? DefaultBooksLibraryId { get; set; } = "";
+
         public SectionSettings[] SectionSettings { get; set; } = Array.Empty<SectionSettings>();
     }
 

--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
@@ -100,6 +100,13 @@
                                     </select>
                                     <div class="fieldDescription">Select the specific music library to use for navigation. Lists all underlying library folders (not grouped views).<br><strong>Requires Jellyfin restart to take effect.</strong></div>
                                 </div>
+                                <div class="inputContainer">
+                                    <label class="inputLabel inputLabelUnfocused" for="defaultBooksLibrary">Default Books Library</label>
+                                    <select is="emby-select" id="defaultBooksLibrary" class="emby-select-withcolor emby-select">
+                                        <option value="">Default</option>
+                                    </select>
+                                    <div class="fieldDescription">Select the specific books library to use for navigation. Lists all underlying library folders (not grouped views).<br><strong>Requires Jellyfin restart to take effect.</strong></div>
+                                </div>
                             </div>
                         </details>
                     </div>
@@ -244,13 +251,15 @@
                     const moviesSelect = document.querySelector('#defaultMoviesLibrary');
                     const tvShowsSelect = document.querySelector('#defaultTVShowsLibrary');
                     const musicSelect = document.querySelector('#defaultMusicLibrary');
+                    const booksSelect = document.querySelector('#defaultBooksLibrary');
 
                     moviesSelect.innerHTML = '<option value="">Default</option>';
                     tvShowsSelect.innerHTML = '<option value="">Default</option>';
                     musicSelect.innerHTML = '<option value="">Default</option>';
+                    booksSelect.innerHTML = '<option value="">Default</option>';
 
                     result.forEach(function (folder) {
-                         if (folder.CollectionType === 'movies' || folder.CollectionType === 'tvshows' || folder.CollectionType === 'music') {
+                         if (folder.CollectionType === 'movies' || folder.CollectionType === 'tvshows' || folder.CollectionType === 'music' || folder.CollectionType === 'books') {
                              const option = document.createElement('option');
                             let folderId = folder.ItemId;
                             if (folderId && !folderId.includes('-')) {
@@ -262,6 +271,7 @@
                             if(folder.CollectionType === 'movies') moviesSelect.appendChild(option);
                             if(folder.CollectionType === 'tvshows') tvShowsSelect.appendChild(option);
                             if(folder.CollectionType === 'music') musicSelect.appendChild(option);
+                            if(folder.CollectionType === 'books') booksSelect.appendChild(option);
                         }
                     });
                 }).catch(function (error) {
@@ -283,6 +293,7 @@
                     DefaultMoviesLibraryId: document.querySelector('#defaultMoviesLibrary').value,
                     DefaultTVShowsLibraryId: document.querySelector('#defaultTVShowsLibrary').value,
                     DefaultMusicLibraryId: document.querySelector('#defaultMusicLibrary').value,
+                    DefaultBooksLibraryId: document.querySelector('#defaultBooksLibrary').value,
                     SectionSettings: []
                 };
 
@@ -326,6 +337,9 @@
                             }
                             if (config.DefaultMusicLibraryId) {
                                 document.querySelector('#defaultMusicLibrary').value = config.DefaultMusicLibraryId;
+                            }
+                            if (config.DefaultBooksLibraryId) {
+                                document.querySelector('#defaultBooksLibrary').value = config.DefaultBooksLibraryId;
                             }
                         }, 500);
 

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/HomeScreenManager.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/HomeScreenManager.cs
@@ -52,9 +52,13 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen
             RegisterResultsDelegate<RecentlyAddedShowsSection>();
             RegisterResultsDelegate<RecentlyAddedAlbumsSection>();
             RegisterResultsDelegate<RecentlyAddedArtistsSection>();
+            RegisterResultsDelegate<RecentlyAddedBooksSection>();
+            RegisterResultsDelegate<RecentlyAddedAudioBooksSection>();
             RegisterResultsDelegate<LatestMoviesSection>();
             RegisterResultsDelegate<LatestShowsSection>();
             RegisterResultsDelegate<LatestAlbumsSection>();
+            RegisterResultsDelegate<LatestBooksSection>();
+            RegisterResultsDelegate<LatestAudioBooksSection>();
             RegisterResultsDelegate<BecauseYouWatchedSection>();
             RegisterResultsDelegate<LiveTvSection>();
             RegisterResultsDelegate<MyListSection>();

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/LatestAudioBooksSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/LatestAudioBooksSection.cs
@@ -1,0 +1,134 @@
+using Jellyfin.Plugin.HomeScreenSections.Configuration;
+using Jellyfin.Plugin.HomeScreenSections.Library;
+using Jellyfin.Plugin.HomeScreenSections.Model.Dto;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Http;
+
+namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
+{
+    public class LatestAudioBooksSection : IHomeScreenSection
+    {
+        public string? Section => "LatestAudioBooks";
+        
+        public string? DisplayText { get; set; } = "Latest Audiobooks";
+        
+        public int? Limit => 1;
+
+        public string? Route => "books";
+        
+        public string? AdditionalData { get; set; } = "audiobooks";
+        
+        public object? OriginalPayload { get; set; } = null;
+        
+        private readonly IUserViewManager m_userViewManager;
+        private readonly IUserManager m_userManager;
+        private readonly ILibraryManager m_libraryManager;
+        private readonly IDtoService m_dtoService;
+
+        public LatestAudioBooksSection(IUserViewManager userViewManager,
+            IUserManager userManager,
+            ILibraryManager libraryManager,
+            IDtoService dtoService)
+        {
+            m_userViewManager = userViewManager;
+            m_userManager = userManager;
+            m_libraryManager = libraryManager;
+            m_dtoService = dtoService;
+        }
+        
+
+        public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload, IQueryCollection queryCollection)
+        {
+            DtoOptions? dtoOptions = new DtoOptions
+            {
+                Fields = new List<ItemFields>
+                {
+                    ItemFields.PrimaryImageAspectRatio,
+                    ItemFields.Path
+                }
+            };
+
+            dtoOptions.ImageTypeLimit = 1;
+            dtoOptions.ImageTypes = new List<ImageType>
+            {
+                ImageType.Primary,
+                ImageType.Thumb,
+                ImageType.Backdrop,
+            };
+            
+            User? user = m_userManager.GetUserById(payload.UserId);
+
+            IReadOnlyList<BaseItem> latestAudioBooks = m_libraryManager.GetItemList(new InternalItemsQuery(user)
+            {
+                IncludeItemTypes = new[]
+                {
+                    BaseItemKind.AudioBook
+                },
+                Limit = 16,
+                OrderBy = new[]
+                {
+                    (ItemSortBy.PremiereDate, SortOrder.Descending)
+                }
+            });
+
+            return new QueryResult<BaseItemDto>(Array.ConvertAll(latestAudioBooks.ToArray(),
+                i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)));
+        }
+
+
+        public IHomeScreenSection CreateInstance(Guid? userId, IEnumerable<IHomeScreenSection>? otherInstances = null)
+        {
+            User? user = m_userManager.GetUserById(userId ?? Guid.Empty);
+
+            BaseItemDto? originalPayload = null;
+            
+            var booksFolders = m_libraryManager.GetUserRootFolder()
+                .GetChildren(user, true)
+                .OfType<Folder>()
+                .Where(x => (x as ICollectionFolder)?.CollectionType == CollectionType.books)
+                .ToArray();
+            
+            var config = HomeScreenSectionsPlugin.Instance?.Configuration;
+            var folder = !string.IsNullOrEmpty(config?.DefaultBooksLibraryId)
+                ? booksFolders.FirstOrDefault(x => x.Id.ToString() == config.DefaultBooksLibraryId)
+                : null;
+            
+            folder ??= booksFolders.FirstOrDefault();
+            
+            if (folder != null)
+            {
+                DtoOptions dtoOptions = new DtoOptions();
+                dtoOptions.Fields =
+                    [..dtoOptions.Fields, ItemFields.PrimaryImageAspectRatio, ItemFields.DisplayPreferencesId];
+                
+                originalPayload = Array.ConvertAll(new[] { folder }, i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)).First();
+            }
+
+            return new LatestAudioBooksSection(m_userViewManager, m_userManager, m_libraryManager, m_dtoService)
+            {
+                DisplayText = DisplayText,
+                AdditionalData = AdditionalData,
+                OriginalPayload = originalPayload
+            };
+        }
+        
+        public HomeScreenSectionInfo GetInfo()
+        {
+            return new HomeScreenSectionInfo
+            {
+                Section = Section,
+                DisplayText = DisplayText,
+                AdditionalData = AdditionalData,
+                Route = Route,
+                Limit = Limit ?? 1,
+                OriginalPayload = OriginalPayload,
+                ViewMode = SectionViewMode.Portrait
+            };
+        }
+    }
+}

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/LatestBooksSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/LatestBooksSection.cs
@@ -1,0 +1,132 @@
+using Jellyfin.Plugin.HomeScreenSections.Configuration;
+using Jellyfin.Plugin.HomeScreenSections.Library;
+using Jellyfin.Plugin.HomeScreenSections.Model.Dto;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Http;
+
+namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
+{
+    public class LatestBooksSection : IHomeScreenSection
+    {
+        public string? Section => "LatestBooks";
+        
+        public string? DisplayText { get; set; } = "Latest Books";
+        
+        public int? Limit => 1;
+
+        public string? Route => "books";
+        
+        public string? AdditionalData { get; set; } = "books";
+        
+        public object? OriginalPayload { get; set; } = null;
+        
+        private readonly IUserViewManager m_userViewManager;
+        private readonly IUserManager m_userManager;
+        private readonly ILibraryManager m_libraryManager;
+        private readonly IDtoService m_dtoService;
+
+        public LatestBooksSection(IUserViewManager userViewManager,
+            IUserManager userManager,
+            ILibraryManager libraryManager,
+            IDtoService dtoService)
+        {
+            m_userViewManager = userViewManager;
+            m_userManager = userManager;
+            m_libraryManager = libraryManager;
+            m_dtoService = dtoService;
+        }
+        
+        public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload, IQueryCollection queryCollection)
+        {
+            DtoOptions? dtoOptions = new DtoOptions
+            {
+                Fields = new List<ItemFields>
+                {
+                    ItemFields.PrimaryImageAspectRatio,
+                    ItemFields.Path
+                }
+            };
+
+            dtoOptions.ImageTypeLimit = 1;
+            dtoOptions.ImageTypes = new List<ImageType>
+            {
+                ImageType.Primary,
+                ImageType.Thumb,
+                ImageType.Backdrop,
+            };
+            
+            User? user = m_userManager.GetUserById(payload.UserId);
+
+            IReadOnlyList<BaseItem> latestBooks = m_libraryManager.GetItemList(new InternalItemsQuery(user)
+            {
+                IncludeItemTypes = new[]
+                {
+                    BaseItemKind.Book
+                },
+                Limit = 16,
+                OrderBy = new[]
+                {
+                    (ItemSortBy.PremiereDate, SortOrder.Descending)
+                }
+            });
+
+            return new QueryResult<BaseItemDto>(Array.ConvertAll(latestBooks.ToArray(),
+                i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)));
+        }
+
+        public IHomeScreenSection CreateInstance(Guid? userId, IEnumerable<IHomeScreenSection>? otherInstances = null)
+        {
+            User? user = m_userManager.GetUserById(userId ?? Guid.Empty);
+
+            BaseItemDto? originalPayload = null;
+            
+            var booksFolders = m_libraryManager.GetUserRootFolder()
+                .GetChildren(user, true)
+                .OfType<Folder>()
+                .Where(x => (x as ICollectionFolder)?.CollectionType == CollectionType.books)
+                .ToArray();
+            
+            var config = HomeScreenSectionsPlugin.Instance?.Configuration;
+            var folder = !string.IsNullOrEmpty(config?.DefaultBooksLibraryId)
+                ? booksFolders.FirstOrDefault(x => x.Id.ToString() == config.DefaultBooksLibraryId)
+                : null;
+            
+            folder ??= booksFolders.FirstOrDefault();
+            
+            if (folder != null)
+            {
+                DtoOptions dtoOptions = new DtoOptions();
+                dtoOptions.Fields =
+                    [..dtoOptions.Fields, ItemFields.PrimaryImageAspectRatio, ItemFields.DisplayPreferencesId];
+                
+                originalPayload = Array.ConvertAll(new[] { folder }, i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)).First();
+            }
+
+            return new LatestBooksSection(m_userViewManager, m_userManager, m_libraryManager, m_dtoService)
+            {
+                DisplayText = DisplayText,
+                AdditionalData = AdditionalData,
+                OriginalPayload = originalPayload
+            };
+        }
+        
+        public HomeScreenSectionInfo GetInfo()
+        {
+            return new HomeScreenSectionInfo
+            {
+                Section = Section,
+                DisplayText = DisplayText,
+                AdditionalData = AdditionalData,
+                Route = Route,
+                Limit = Limit ?? 1,
+                OriginalPayload = OriginalPayload,
+                ViewMode = SectionViewMode.Portrait
+            };
+        }
+    }
+}

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/RecentlyAddedAudioBooksSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/RecentlyAddedAudioBooksSection.cs
@@ -1,0 +1,135 @@
+using Jellyfin.Plugin.HomeScreenSections.Configuration;
+using Jellyfin.Plugin.HomeScreenSections.Library;
+using Jellyfin.Plugin.HomeScreenSections.Model.Dto;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Http;
+
+namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
+{
+    public class RecentlyAddedAudioBooksSection : IHomeScreenSection
+    {
+        public string? Section => "RecentlyAddedAudioBooks";
+
+        public string? DisplayText { get; set; } = "Recently Added Audiobooks";
+
+        public int? Limit => 1;
+
+        public string? Route => "books";
+
+        public string? AdditionalData { get; set; } = "audiobooks";
+
+        public object? OriginalPayload { get; set; } = null;
+        
+        private readonly IUserViewManager m_userViewManager;
+        private readonly IUserManager m_userManager;
+        private readonly ILibraryManager m_libraryManager;
+        private readonly IDtoService m_dtoService;
+
+        public RecentlyAddedAudioBooksSection(IUserViewManager userViewManager,
+            IUserManager userManager,
+            ILibraryManager libraryManager,
+            IDtoService dtoService)
+        {
+            m_userViewManager = userViewManager;
+            m_userManager = userManager;
+            m_libraryManager = libraryManager;
+            m_dtoService = dtoService;
+        }
+
+
+        public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload, IQueryCollection queryCollection)
+        {
+            User? user = m_userManager.GetUserById(payload.UserId);
+
+            DtoOptions? dtoOptions = new DtoOptions
+            {
+                Fields = new List<ItemFields>
+                {
+                    ItemFields.PrimaryImageAspectRatio,
+                    ItemFields.Path
+                }
+            };
+
+            dtoOptions.ImageTypeLimit = 1;
+            dtoOptions.ImageTypes = new List<ImageType>
+            {
+                ImageType.Primary,
+                ImageType.Thumb,
+                ImageType.Backdrop,
+            };
+
+            IReadOnlyList<BaseItem> recentlyAddedAudioBooks = m_libraryManager.GetItemList(new InternalItemsQuery(user)
+            {
+                IncludeItemTypes = new[]
+                {
+                    BaseItemKind.AudioBook
+                },
+                Limit = 16,
+                OrderBy = new[]
+                {
+                    (ItemSortBy.DateCreated, SortOrder.Descending)
+                },
+                DtoOptions = dtoOptions
+            });
+
+            return new QueryResult<BaseItemDto>(Array.ConvertAll(recentlyAddedAudioBooks.ToArray(),
+                i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)));
+        }
+
+
+        public IHomeScreenSection CreateInstance(Guid? userId, IEnumerable<IHomeScreenSection>? otherInstances = null)
+        {
+            User? user = m_userManager.GetUserById(userId ?? Guid.Empty);
+
+            BaseItemDto? originalPayload = null;
+            
+            var booksFolders = m_libraryManager.GetUserRootFolder()
+                .GetChildren(user, true)
+                .OfType<Folder>()
+                .Where(x => (x as ICollectionFolder)?.CollectionType == CollectionType.books)
+                .ToArray();
+            
+            var config = HomeScreenSectionsPlugin.Instance?.Configuration;
+            var folder = !string.IsNullOrEmpty(config?.DefaultBooksLibraryId)
+                ? booksFolders.FirstOrDefault(x => x.Id.ToString() == config.DefaultBooksLibraryId)
+                : null;
+            
+            folder ??= booksFolders.FirstOrDefault();
+            
+            if (folder != null)
+            {
+                DtoOptions dtoOptions = new DtoOptions();
+                dtoOptions.Fields =
+                    [..dtoOptions.Fields, ItemFields.PrimaryImageAspectRatio, ItemFields.DisplayPreferencesId];
+
+                originalPayload = Array.ConvertAll(new[] { folder }, i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)).First();
+            }
+
+            return new RecentlyAddedAudioBooksSection(m_userViewManager, m_userManager, m_libraryManager, m_dtoService)
+            {
+                AdditionalData = AdditionalData,
+                DisplayText = DisplayText,
+                OriginalPayload = originalPayload
+            };
+        }
+        
+        public HomeScreenSectionInfo GetInfo()
+        {
+            return new HomeScreenSectionInfo
+            {
+                Section = Section,
+                DisplayText = DisplayText,
+                AdditionalData = AdditionalData,
+                Route = Route,
+                Limit = Limit ?? 1,
+                OriginalPayload = OriginalPayload,
+                ViewMode = SectionViewMode.Portrait
+            };
+        }
+    }
+}

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/RecentlyAddedBooksSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/RecentlyAddedBooksSection.cs
@@ -1,0 +1,135 @@
+using Jellyfin.Plugin.HomeScreenSections.Configuration;
+using Jellyfin.Plugin.HomeScreenSections.Library;
+using Jellyfin.Plugin.HomeScreenSections.Model.Dto;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Http;
+
+namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
+{
+    public class RecentlyAddedBooksSection : IHomeScreenSection
+    {
+        public string? Section => "RecentlyAddedBooks";
+
+        public string? DisplayText { get; set; } = "Recently Added Books";
+
+        public int? Limit => 1;
+
+        public string? Route => "books";
+
+        public string? AdditionalData { get; set; } = "books";
+
+        public object? OriginalPayload { get; set; } = null;
+        
+        private readonly IUserViewManager m_userViewManager;
+        private readonly IUserManager m_userManager;
+        private readonly ILibraryManager m_libraryManager;
+        private readonly IDtoService m_dtoService;
+
+        public RecentlyAddedBooksSection(IUserViewManager userViewManager,
+            IUserManager userManager,
+            ILibraryManager libraryManager,
+            IDtoService dtoService)
+        {
+            m_userViewManager = userViewManager;
+            m_userManager = userManager;
+            m_libraryManager = libraryManager;
+            m_dtoService = dtoService;
+        }
+
+
+        public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload, IQueryCollection queryCollection)
+        {
+            User? user = m_userManager.GetUserById(payload.UserId);
+
+            DtoOptions? dtoOptions = new DtoOptions
+            {
+                Fields = new List<ItemFields>
+                {
+                    ItemFields.PrimaryImageAspectRatio,
+                    ItemFields.Path
+                }
+            };
+
+            dtoOptions.ImageTypeLimit = 1;
+            dtoOptions.ImageTypes = new List<ImageType>
+            {
+                ImageType.Primary,
+                ImageType.Thumb,
+                ImageType.Backdrop,
+            };
+
+            IReadOnlyList<BaseItem> recentlyAddedBooks = m_libraryManager.GetItemList(new InternalItemsQuery(user)
+            {
+                IncludeItemTypes = new[]
+                {
+                    BaseItemKind.Book
+                },
+                Limit = 16,
+                OrderBy = new[]
+                {
+                    (ItemSortBy.DateCreated, SortOrder.Descending)
+                },
+                DtoOptions = dtoOptions
+            });
+
+            return new QueryResult<BaseItemDto>(Array.ConvertAll(recentlyAddedBooks.ToArray(),
+                i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)));
+        }
+
+
+        public IHomeScreenSection CreateInstance(Guid? userId, IEnumerable<IHomeScreenSection>? otherInstances = null)
+        {
+            User? user = m_userManager.GetUserById(userId ?? Guid.Empty);
+
+            BaseItemDto? originalPayload = null;
+            
+            var booksFolders = m_libraryManager.GetUserRootFolder()
+                .GetChildren(user, true)
+                .OfType<Folder>()
+                .Where(x => (x as ICollectionFolder)?.CollectionType == CollectionType.books)
+                .ToArray();
+            
+            var config = HomeScreenSectionsPlugin.Instance?.Configuration;
+            var folder = !string.IsNullOrEmpty(config?.DefaultBooksLibraryId)
+                ? booksFolders.FirstOrDefault(x => x.Id.ToString() == config.DefaultBooksLibraryId)
+                : null;
+            
+            folder ??= booksFolders.FirstOrDefault();
+            
+            if (folder != null)
+            {
+                DtoOptions dtoOptions = new DtoOptions();
+                dtoOptions.Fields =
+                    [..dtoOptions.Fields, ItemFields.PrimaryImageAspectRatio, ItemFields.DisplayPreferencesId];
+
+                originalPayload = Array.ConvertAll(new[] { folder }, i => m_dtoService.GetBaseItemDto(i, dtoOptions, user)).First();
+            }
+
+            return new RecentlyAddedBooksSection(m_userViewManager, m_userManager, m_libraryManager, m_dtoService)
+            {
+                AdditionalData = AdditionalData,
+                DisplayText = DisplayText,
+                OriginalPayload = originalPayload
+            };
+        }
+        
+        public HomeScreenSectionInfo GetInfo()
+        {
+            return new HomeScreenSectionInfo
+            {
+                Section = Section,
+                DisplayText = DisplayText,
+                AdditionalData = AdditionalData,
+                Route = Route,
+                Limit = Limit ?? 1,
+                OriginalPayload = OriginalPayload,
+                ViewMode = SectionViewMode.Portrait
+            };
+        }
+    }
+}


### PR DESCRIPTION
closes https://features.iamparadox.dev/posts/5/add-section-for-ebooks and maybe https://github.com/IAmParadox27/jellyfin-plugin-home-sections/issues/13 too? unsure if the second media libraries has been added yet

adds 4 new sections:

### Recently Added Books
<img width="2378" height="432" alt="2025-09-06_21-20" src="https://github.com/user-attachments/assets/72e115d2-87fc-4110-bfa5-8d105e2f9b97" />

### Latest Books
<img width="2367" height="436" alt="2025-09-06_21-21" src="https://github.com/user-attachments/assets/5c21b0e0-8f3e-4cdf-afc3-50041c60dfe0" />

### Recently Added Audiobooks

### Latest Audiobooks

i need help testing the audiobook sections because i don't have any audiobooks in my library. i don't see why it wouldn't work as these changes have been largely the same, but i'd prefer to have confirmation before merging. perhaps @HammyHavoc has an audiobook library available to test?

