### PR TITLE
Add new Ready and Meta endpoints (PR 70 split) 

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/Controllers/loadSections.js
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Controllers/loadSections.js
@@ -172,7 +172,7 @@
     }
     
     async function isUserUsingHomeScreenSections(_userSettings, _apiClient) {
-        var pluginConfig = await _apiClient.getJSON(_apiClient.getUrl("HomeScreen/Configuration"));
+        var pluginConfig = await _apiClient.getJSON(_apiClient.getUrl("HomeScreen/Meta"));
         
         if (pluginConfig.AllowUserOverride === true) {
             if (_userSettings && _userSettings.getData() && _userSettings.getData().CustomPrefs && _userSettings.getData().CustomPrefs.useModularHome !== undefined) {


### PR DESCRIPTION
New endpoints
/Ready
Allows external plugins to verify that the home screen system is fully initialized before attempting section registration. If used, this should fix a startup race condition causing external plugins to not register. (Resolves: https://github.com/IAmParadox27/jellyfin-plugin-collection-sections/issues/4)
- Returns 200 when ready or 503 when not ready

/Meta
An authenticated, lightweight endpoint that returns minimal plugin status. For now replaces a "HomeScreen/Configuration" call. For PR 70, it is used by the user configuration to determine whether to load user configurations or not.
- Returns { "Enabled": boolean, "AllowUserOverride": boolean }