### PR TITLE
Cache busting and API authentication

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/PluginConfiguration.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/PluginConfiguration.cs
@@ -32,8 +32,6 @@ namespace Jellyfin.Plugin.HomeScreenSections.Configuration
 
         public int CacheTimeoutSeconds { get; set; } = 86400;
 
-        public string? ConfigVersion { get; set; } = null;
-
         public SectionSettings[] SectionSettings { get; set; } = Array.Empty<SectionSettings>();
     }
 

--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/PluginConfiguration.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/PluginConfiguration.cs
@@ -26,6 +26,14 @@ namespace Jellyfin.Plugin.HomeScreenSections.Configuration
         
         public string? DefaultBooksLibraryId { get; set; } = "";
 
+        public bool DeveloperMode { get; set; } = false;
+
+        public int CacheBustCounter { get; set; } = 0;
+
+        public int CacheTimeoutSeconds { get; set; } = 86400;
+
+        public string? ConfigVersion { get; set; } = null;
+
         public SectionSettings[] SectionSettings { get; set; } = Array.Empty<SectionSettings>();
     }
 

--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
@@ -132,10 +132,19 @@
                             <div class="fieldDescription">Disable browser caching for plugin resources during development.</div>
                         </div>
                         <div style="margin-top: 1em;">
-                            <button type="button" id="btnBustCache" class="raised button-submit emby-button" style="margin-right: 1em;">
-                                <span>Bust Cache Now</span>
-                            </button>
-                            <span id="cacheBustStatus" style="color: #52b54b; display: none;">Cache busted successfully</span>
+                            <div style="display: flex; gap: 1em; align-items: center; flex-wrap: wrap;">
+                                <button type="button" id="btnBustHomeSectionsCache" class="raised button-submit emby-button">
+                                    <span>Bust Static Assets Cache</span>
+                                </button>
+                                <button type="button" id="btnBustAllCaches" class="raised emby-button" style="background-color: #2196F3;">
+                                    <span>Bust All Caches (Assets + Index)</span>
+                                </button>
+                                <span id="cacheBustStatus" style="color: #52b54b; display: none; font-weight: bold;"></span>
+                            </div>
+                            <div style="margin-top: 0.5em; font-size: 0.9em; color: #ccc;">
+                                <strong>Static Assets Cache:</strong> Clears browser cache for CSS/JS files only.<br>
+                                <strong>All Caches:</strong> Clears both static assets and index.html transformation cache.
+                            </div>
                         </div>
                     </div>
                 </fieldset>
@@ -226,7 +235,10 @@
 
     <script type="text/javascript">
         (() => {
+            // Plugin GUID for configuration API
             const pluginId = 'b8298e01-2697-407a-b44d-aa8dc795e850';
+            // Plugin assembly name for transformation cache system
+            const pluginAssemblyName = 'Jellyfin.Plugin.HomeScreenSections';
 
             function setupTabs() {
                 const tabs = document.querySelectorAll('.jellyfin-tab-button');
@@ -405,11 +417,27 @@
                 document.querySelector('#btnSaveConfig').addEventListener("click", saveConfig);
 
                 // Cache bust functionality
-                const btnBustCache = document.querySelector('#btnBustCache');
-                if (btnBustCache) {
-                    btnBustCache.addEventListener('click', function() {
-                        btnBustCache.disabled = true;
-                        btnBustCache.innerHTML = '<span>Busting Cache...</span>';
+                const btnBustHomeSectionsCache = document.querySelector('#btnBustHomeSectionsCache');
+                const btnBustAllCaches = document.querySelector('#btnBustAllCaches');
+                const cacheBustStatus = document.getElementById('cacheBustStatus');
+
+                function showStatus(message, isError = false) {
+                    if (cacheBustStatus) {
+                        cacheBustStatus.textContent = message;
+                        cacheBustStatus.style.color = isError ? '#d32f2f' : '#52b54b';
+                        cacheBustStatus.style.display = 'inline';
+                        setTimeout(() => cacheBustStatus.style.display = 'none', 4000);
+                    }
+                }
+
+                function setButtonState(button, loading, originalText) {
+                    button.disabled = loading;
+                    button.innerHTML = loading ? '<span>Busting Cache...</span>' : `<span>${originalText}</span>`;
+                }
+
+                if (btnBustHomeSectionsCache) {
+                    btnBustHomeSectionsCache.addEventListener('click', function() {
+                        setButtonState(btnBustHomeSectionsCache, true, 'Bust Static Assets Cache');
 
                         window.ApiClient.ajax({
                             url: window.ApiClient.getUrl('HomeScreen/BustCache'),
@@ -420,18 +448,71 @@
                                 'Content-Type': 'application/json'
                             }
                         }).then(response => {
-                            const status = document.getElementById('cacheBustStatus');
-                            if (status) {
-                                status.style.display = 'inline';
-                                setTimeout(() => status.style.display = 'none', 3000);
-                            }
+                            showStatus('Static assets cache busted successfully');
                         }).catch(error => {
-                            console.error('Cache bust error:', error);
-                            Dashboard.alert('Failed to bust cache. Check console for details.');
+                            console.error('Static assets cache bust error:', error);
+                            showStatus('Failed to bust static assets cache', true);
                         }).finally(() => {
-                            btnBustCache.disabled = false;
-                            btnBustCache.innerHTML = '<span>Bust Cache Now</span>';
+                            setButtonState(btnBustHomeSectionsCache, false, 'Bust Static Assets Cache');
                         });
+                    });
+                }
+
+                if (btnBustAllCaches) {
+                    btnBustAllCaches.addEventListener('click', function() {
+                        setButtonState(btnBustAllCaches, true, 'Bust All Caches (Assets + Index)');
+                        
+                        // First bust static assets cache (Home Sections)
+                        const staticAssetsPromise = window.ApiClient.ajax({
+                            url: window.ApiClient.getUrl('HomeScreen/BustCache'),
+                            type: 'POST',
+                            dataType: 'json',
+                            headers: {
+                                'Accept': 'application/json',
+                                'Content-Type': 'application/json'
+                            }
+                        });
+
+                        // Then bust index.html transformation cache (for home-sections plugin assembly name)
+                        const indexTransformPromise = window.ApiClient.ajax({
+                            url: window.ApiClient.getUrl('TransformationCache/bust-cache?pluginName=' + encodeURIComponent(pluginAssemblyName)),
+                            type: 'POST',
+                            dataType: 'json',
+                            headers: {
+                                'Accept': 'application/json',
+                                'Content-Type': 'application/json'
+                            }
+                        });
+
+                        Promise.allSettled([staticAssetsPromise, indexTransformPromise])
+                            .then(results => {
+                                const staticResult = results[0];
+                                const transformResult = results[1];
+                                
+                                let message = '';
+                                let isError = false;
+                                
+                                if (staticResult.status === 'fulfilled' && transformResult.status === 'fulfilled') {
+                                    message = 'All caches busted successfully (assets + index)';
+                                } else if (staticResult.status === 'fulfilled' && transformResult.status === 'rejected') {
+                                    console.warn('Transformation cache bust failed:', transformResult.reason);
+                                    if (transformResult.reason?.status === 404) {
+                                        message = 'Static assets cache busted - transformation plugin not found or plugin not registered';
+                                    } else {
+                                        message = 'Static assets cache busted - transformation cache failed (check console)';
+                                    }
+                                } else if (staticResult.status === 'rejected') {
+                                    console.error('Static assets cache bust failed:', staticResult.reason);
+                                    message = 'Failed to bust static assets cache';
+                                    isError = true;
+                                } else {
+                                    message = 'Cache bust completed with mixed results (check console)';
+                                }
+                                
+                                showStatus(message, isError);
+                            }).finally(() => {
+                                setButtonState(btnBustAllCaches, false, 'Bust All Caches (Assets + Index)');
+                            });
                     });
                 }
             });

--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
@@ -76,7 +76,7 @@
                                 </div>
                             </div>
                         </details>
-                         <details>
+                        <details style="margin-bottom: 1em;">
                             <summary style="cursor: pointer; font-weight: bold;">Default Libraries</summary>
                             <div style="padding-top: 1em;">
                                 <div class="inputContainer">
@@ -109,6 +109,34 @@
                                 </div>
                             </div>
                         </details>
+                                <details>
+                            <summary style="cursor: pointer; font-weight: bold;">Cache</summary>
+                            <div style="padding-top: 1em;">
+                                <div class="inputContainer">
+                                    <input is="emby-input" type="number" data-id="txtCacheTimeoutSeconds" label="Cache Timeout (seconds)" min="0" max="604800" />
+                                    <div class="fieldDescription">How long browsers should cache plugin resources (default: 86400 = 24 hours). Set to 0 to disable caching.</div>
+                                </div>
+                            </div>
+                        </details>
+                    </div>
+                </fieldset>
+
+                <fieldset class="verticalSection-extrabottompadding">
+                    <legend style="padding-bottom:10px; font-weight: bolder; font-size: 1.2em;">Developer Settings</legend>
+                    <div style="padding-left: .5em;">
+                        <div class="checkboxContainer checkboxContainer-withDescription" style="margin-bottom: 1.5em;">
+                            <label class="emby-checkbox-label">
+                                <input id="globalDeveloperMode" type="checkbox" is="emby-checkbox" class="emby-checkbox">
+                                <span>Developer Mode</span>
+                            </label>
+                            <div class="fieldDescription">Disable browser caching for plugin resources during development.</div>
+                        </div>
+                        <div style="margin-top: 1em;">
+                            <button type="button" id="btnBustCache" class="raised button-submit emby-button" style="margin-right: 1em;">
+                                <span>Bust Cache Now</span>
+                            </button>
+                            <span id="cacheBustStatus" style="color: #52b54b; display: none;">Cache busted successfully</span>
+                        </div>
                     </div>
                 </fieldset>
             </div>
@@ -294,6 +322,8 @@
                     DefaultTVShowsLibraryId: document.querySelector('#defaultTVShowsLibrary').value,
                     DefaultMusicLibraryId: document.querySelector('#defaultMusicLibrary').value,
                     DefaultBooksLibraryId: document.querySelector('#defaultBooksLibrary').value,
+                    DeveloperMode: document.querySelector('#globalDeveloperMode').checked,
+                    CacheTimeoutSeconds: document.querySelector('[data-id=txtCacheTimeoutSeconds]').value || 86400,
                     SectionSettings: []
                 };
 
@@ -327,6 +357,8 @@
                         document.querySelector('[data-id=txtJellyseerrUrl]').value = config.JellyseerrUrl;
                         document.querySelector('[data-id=txtJellyseerrApiKey]').value = config.JellyseerrApiKey;
                         document.querySelector('[data-id=txtJellyseerrPreferredLanguages]').value = config.JellyseerrPreferredLanguages;
+                        document.querySelector('#globalDeveloperMode').checked = config.DeveloperMode;
+                        document.querySelector('[data-id=txtCacheTimeoutSeconds]').value = config.CacheTimeoutSeconds || 86400;
 
                         setTimeout(function() {
                             if (config.DefaultMoviesLibraryId) {
@@ -371,6 +403,37 @@
                 loadLibraries();
                 loadConfig();
                 document.querySelector('#btnSaveConfig').addEventListener("click", saveConfig);
+
+                // Cache bust functionality
+                const btnBustCache = document.querySelector('#btnBustCache');
+                if (btnBustCache) {
+                    btnBustCache.addEventListener('click', function() {
+                        btnBustCache.disabled = true;
+                        btnBustCache.innerHTML = '<span>Busting Cache...</span>';
+
+                        window.ApiClient.ajax({
+                            url: window.ApiClient.getUrl('HomeScreen/BustCache'),
+                            type: 'POST',
+                            dataType: 'json',
+                            headers: {
+                                'Accept': 'application/json',
+                                'Content-Type': 'application/json'
+                            }
+                        }).then(response => {
+                            const status = document.getElementById('cacheBustStatus');
+                            if (status) {
+                                status.style.display = 'inline';
+                                setTimeout(() => status.style.display = 'none', 3000);
+                            }
+                        }).catch(error => {
+                            console.error('Cache bust error:', error);
+                            Dashboard.alert('Failed to bust cache. Check console for details.');
+                        }).finally(() => {
+                            btnBustCache.disabled = false;
+                            btnBustCache.innerHTML = '<span>Bust Cache Now</span>';
+                        });
+                    });
+                }
             });
         })();
     </script>

--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
@@ -109,7 +109,7 @@
                                 </div>
                             </div>
                         </details>
-                                <details>
+                        <details>
                             <summary style="cursor: pointer; font-weight: bold;">Cache</summary>
                             <div style="padding-top: 1em;">
                                 <div class="inputContainer">

--- a/src/Jellyfin.Plugin.HomeScreenSections/Controllers/ModularHomeViewsController.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Controllers/ModularHomeViewsController.cs
@@ -3,6 +3,7 @@ using Jellyfin.Plugin.HomeScreenSections.Library;
 using MediaBrowser.Model;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Querying;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
@@ -35,6 +36,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.Controllers
         /// <param name="viewName">The view identifier.</param>
         /// <returns>View.</returns>
         [HttpGet("{viewName}")]
+        [Authorize]
         public ActionResult GetView([FromRoute] string viewName)
         {
             return ServeView(viewName);
@@ -45,6 +47,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.Controllers
         /// </summary>
         /// <returns>Array of <see cref="HomeScreenSectionInfo"/>.</returns>
         [HttpGet("Sections")]
+        [Authorize]
         public QueryResult<HomeScreenSectionInfo> GetSectionTypes()
         {
             // Todo add reading whether the section is enabled or disabled by the user.
@@ -70,6 +73,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.Controllers
         /// <param name="userId">The user ID.</param>
         /// <returns><see cref="ModularHomeUserSettings"/>.</returns>
         [HttpGet("UserSettings")]
+        [Authorize]
         public ActionResult<ModularHomeUserSettings> GetUserSettings([FromQuery] Guid userId)
         {
             IEnumerable<SectionSettings> defaultEnabledSections =
@@ -88,6 +92,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.Controllers
         /// <param name="obj">Instance of <see cref="ModularHomeUserSettings" />.</param>
         /// <returns>Status.</returns>
         [HttpPost("UserSettings")]
+        [Authorize]
         public ActionResult UpdateSettings([FromBody] ModularHomeUserSettings obj)
         {
             m_homeScreenManager.UpdateUserSettings(obj.UserId, obj);

--- a/src/Jellyfin.Plugin.HomeScreenSections/Controllers/loadSections.js
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Controllers/loadSections.js
@@ -1,4 +1,17 @@
 ﻿async function test(elem, apiClient, user, userSettings) {
+    if (!isHomePage()) {
+        return;
+    }
+
+    function isHomePage() {
+        const hasIndexPageId = document.getElementById('indexPage') !== null;
+        const hasHomePageClass = document.querySelector('.page.homePage') !== null;
+        const hasSectionsDiv = document.querySelector('.sections') !== null;
+        const hasPageRole = document.querySelector('[data-role="page"]') !== null;
+
+        return hasIndexPageId && hasHomePageClass && hasSectionsDiv && hasPageRole;
+    }
+
     function getHomeScreenSectionFetchFn(serverId, sectionInfo, serverConnections, _userSettings) {
         return function() {
             var __userSettings = _userSettings;

--- a/src/Jellyfin.Plugin.HomeScreenSections/Helpers/TransformationPatches.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Helpers/TransformationPatches.cs
@@ -38,6 +38,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.Helpers
         public static string IndexHtml(PatchRequestPayload content)
         {
             NetworkConfiguration networkConfiguration = HomeScreenSectionsPlugin.Instance.ServerConfigurationManager.GetNetworkConfiguration();
+            var pluginConfig = HomeScreenSectionsPlugin.Instance.Configuration;
 
             string rootPath = "";
             if (!string.IsNullOrWhiteSpace(networkConfiguration.BaseUrl))
@@ -45,8 +46,22 @@ namespace Jellyfin.Plugin.HomeScreenSections.Helpers
                 rootPath = $"/{networkConfiguration.BaseUrl.TrimStart('/').Trim()}";
             }
             
-            string replacementText0 = $"<link rel=\"stylesheet\" href=\"{rootPath}/HomeScreen/home-screen-sections.css\" />";
-            string replacementText1 = $"<script type=\"text/javascript\" plugin=\"Jellyfin.Plugin.HomeScreenSections\" src=\"{rootPath}/HomeScreen/home-screen-sections.js\" defer></script>";
+            string pluginVersion = HomeScreenSectionsPlugin.Instance.GetCurrentPluginVersion();
+
+            string cacheParam;
+            if (pluginConfig.DeveloperMode)
+            {
+                // Developer mode: Add timestamp
+                cacheParam = $"?v={pluginVersion}&t={DateTimeOffset.UtcNow.Ticks}";
+            }
+            else
+            {
+                // Normal mode: Use version + cache bust counter
+                cacheParam = $"?v={pluginVersion}&c={pluginConfig.CacheBustCounter}";
+            }
+
+            string replacementText0 = $"<link rel=\"stylesheet\" href=\"{rootPath}/HomeScreen/home-screen-sections.css{cacheParam}\" />";
+            string replacementText1 = $"<script type=\"text/javascript\" plugin=\"Jellyfin.Plugin.HomeScreenSections\" src=\"{rootPath}/HomeScreen/home-screen-sections.js{cacheParam}\" defer></script>";
             
             return content.Contents!
                 .Replace("</head>", $"{replacementText0}</head>")

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreenSectionsPlugin.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreenSectionsPlugin.cs
@@ -96,5 +96,47 @@ namespace Jellyfin.Plugin.HomeScreenSections
                 }
             };
         }
+
+        /// <summary>
+        /// Override UpdateConfiguration to preserve cache bust counter and config version.
+        /// </summary>
+        /// <param name="configuration">The new configuration to save</param>
+        public override void UpdateConfiguration(BasePluginConfiguration configuration)
+        {
+            if (configuration is PluginConfiguration pluginConfig)
+            {
+                var currentConfig = base.Configuration;
+
+                // Handle cache busting when developer mode is turned ON
+                if (!currentConfig.DeveloperMode && pluginConfig.DeveloperMode)
+                {
+                    pluginConfig.CacheBustCounter = currentConfig.CacheBustCounter + 1;
+                }
+                else
+                {
+                    pluginConfig.CacheBustCounter = currentConfig.CacheBustCounter;
+                }
+            }
+
+            base.UpdateConfiguration(configuration);
+        }
+
+        /// <summary>
+        /// Increment the cache bust counter and save configuration.
+        /// </summary>
+        public void BustCache()
+        {
+            var config = base.Configuration;
+            config.CacheBustCounter++;
+            base.UpdateConfiguration(config);
+        }
+
+        /// <summary>
+        /// Get the current plugin version.
+        /// </summary>
+        public string GetCurrentPluginVersion()
+        {
+            return base.Version?.ToString() ?? "0.0.0";
+        }
     }
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/Properties/AssemblyInfo.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Properties/AssemblyInfo.cs
@@ -6,4 +6,5 @@ using Jellyfin.Plugin.HomeScreenSections.Attributes;
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyTitle("Jellyfin.Plugin.HomeScreenSections")]
 [assembly: AssemblyVersion("2.3.0.0")]
-[assembly: JellyfinVersion("10.11.0-rc5")]
+[assembly: JellyfinVersion("10.10.7")]
+//[assembly: JellyfinVersion("10.11.0-rc5")]


### PR DESCRIPTION
Issue: The GetCurrentPluginVersion() returns the \<Version\> in Jellyfin.Plugin.HomeScreenSections.csproj which is currently 2.3.0.0.  Is there a way to get the current plugin version 2.3.7.0? Otherwise is it possible to iterate this on release?

### Cache System
<img width="1042" height="524" alt="image" src="https://github.com/user-attachments/assets/133bcf93-c480-4b73-b10c-6562fd6df4b3" />


**Automatic Version-Based Cache Busting**
- Plugin resources include version parameters: `plugin.js?v=2.3.0.0&c=1`
- Cache parameters automatically change when plugin version updates
- Ensures users get fresh resources after plugin upgrades

**Manual Cache Invalidation**
- Admin "Bust Cache Now" button for immediate cache clearing
- Increments cache counter, forcing fresh downloads on next page load
- No server restart required

**Developer Mode**
- Toggleable developer mode that completely disables caching
- Auto-increments cache counter when enabled/disabled
- Adds timestamp-based parameters for guaranteed cache bypass

#### HTTP Response Headers
```csharp
// Developer Mode
Cache-Control: no-cache, no-store, must-revalidate
Pragma: no-cache
Expires: 0

// Normal Mode  
Cache-Control: public, max-age=86400
ETag: "v2.3.0.0-c1"
```

#### Resource URL Injection
```html
<!-- Normal Mode -->
<script src="/HomeScreen/home-screen-sections.js?v=2.3.0.0&c=1" defer></script>

<!-- Developer Mode -->
<script src="/HomeScreen/home-screen-sections.js?v=2.3.0.0-dev-637849382742813456" defer></script>
```
<img width="538" height="93" alt="image" src="https://github.com/user-attachments/assets/f511c1ab-d532-483d-b6ea-e3182a7abf71" />

<img width="504" height="104" alt="image" src="https://github.com/user-attachments/assets/fbb9ec73-fd47-44aa-9dd0-4de67a97404f" />

### Other changes
- (PR 70 split) Add API authentication
- (PR 70 split) Do not inject if not on homepage