### PR TITLE
feat: allow admin to hide watched items

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/PluginConfiguration.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/PluginConfiguration.cs
@@ -43,8 +43,6 @@ namespace Jellyfin.Plugin.HomeScreenSections.Configuration
 
         public int CacheTimeoutSeconds { get; set; } = 86400;
 
-        public bool HideWatchedItems { get; set; } = false;
-
         public SectionSettings[] SectionSettings { get; set; } = Array.Empty<SectionSettings>();
     }
 
@@ -78,6 +76,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.Configuration
         public int OrderIndex { get; set; }
         
         public SectionViewMode ViewMode { get; set; } = SectionViewMode.Landscape;
+
+        public bool HideWatchedItems { get; set; } = false;
     }
     
     public class ArrConfig

--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
@@ -40,13 +40,6 @@
                         </label>
                         <div class="fieldDescription">Can users enable/disable this plugin for their own view?</div>
                     </div>
-                    <div class="checkboxContainer checkboxContainer-withDescription">
-                        <label class="emby-checkbox-label">
-                            <input id="hideWatchedItems" type="checkbox" is="emby-checkbox" class="emby-checkbox">
-                            <span>Hide Watched Items</span>
-                        </label>
-                        <div class="fieldDescription">Hide watched movies and shows?</div>
-                    </div>
                 </div>
             </fieldset>
 
@@ -286,6 +279,7 @@
                             <th style="text-align: center; vertical-align: middle; padding: 8px 12px; font-weight: bold;">Order</th>
                             <th style="text-align: center; vertical-align: middle; padding: 8px 12px; font-weight: bold;">Enabled</th>
                             <th style="text-align: center; vertical-align: middle; padding: 8px 12px; font-weight: bold;">User Override</th>
+                            <th style="text-align: center; vertical-align: middle; padding: 8px 12px; font-weight: bold;">Hide Watched</th>
                             <th style="text-align: center; vertical-align: middle; padding: 8px 12px; font-weight: bold;">Min</th>
                             <th style="text-align: center; vertical-align: middle; padding: 8px 12px; font-weight: bold;">Max</th>
                             <th style="text-align: center; vertical-align: middle; padding: 8px 12px; font-weight: bold;">View Mode</th>
@@ -326,6 +320,16 @@
             <td style="text-align: center; vertical-align: middle; padding: 8px 12px;">
                 <label style="width: 0;" class="emby-checkbox-label">
                     <input data-id="chkSectionUserOverrideAllowed" type="checkbox" is="emby-checkbox" data-embycheckbox="true" class="emby-checkbox">
+                    <span class="checkboxLabel"></span>
+                    <span class="checkboxOutline">
+                        <span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>
+                        <span class="material-icons checkboxIcon checkboxIcon-unchecked " aria-hidden="true"></span>
+                    </span>
+                </label>
+            </td>
+                        <td style="text-align: center; vertical-align: middle; padding: 8px 12px;">
+                <label style="width: 0;" class="emby-checkbox-label">
+                    <input data-id="chkHideWatchedItems" type="checkbox" is="emby-checkbox" data-embycheckbox="true" class="emby-checkbox">
                     <span class="checkboxLabel"></span>
                     <span class="checkboxOutline">
                         <span class="material-icons checkboxIcon checkboxIcon-checked check" aria-hidden="true"></span>
@@ -428,6 +432,15 @@
                     viewModeSelect.setAttribute('disabled', true);
                 }
 
+                const hideWatchedCheckbox = template.querySelector('[data-id=chkHideWatchedItems]');
+                const hideWatchedLabel = hideWatchedCheckbox.closest('.emby-checkbox-label');
+                hideWatchedCheckbox.checked = sectionConfig.HideWatchedItems
+                if (!sectionInfo.AllowHideWatched && hideWatchedLabel) {
+                    hideWatchedCheckbox.setAttribute('disabled', true);
+                    hideWatchedLabel.style.opacity = '0.5';
+                    hideWatchedLabel.style.cursor = 'default';
+                }
+
                 sectionWrapper.appendChild(template);
             }
 
@@ -470,7 +483,6 @@
                 const config = {
                     Enabled: document.querySelector('#globalEnabledDefault').checked,
                     AllowUserOverride: document.querySelector('#globalAllowUserOverride').checked,
-                    HideWatchedItems: document.querySelector('#hideWatchedItems').checked,
                     LibreTranslateUrl: document.querySelector('[data-id=txtLibreTranslateUrl]').value,
                     LibreTranslateApiKey: document.querySelector('[data-id=txtLibreTranslateApiKey]').value,
                     JellyseerrUrl: document.querySelector('[data-id=txtJellyseerrUrl]').value,
@@ -500,6 +512,7 @@
                         UpperLimit: row.querySelector('[data-id=txtSectionMaxLimit]').value,
                         OrderIndex: row.querySelector('[data-id=txtOrderIndex]').value,
                         ViewMode: row.querySelector('[data-id=viewModeSelect]').value,
+                        HideWatchedItems: row.querySelector('[data-id=chkHideWatchedItems]').checked,
                     };
                     config.SectionSettings.push(sectionConfig);
                 });
@@ -516,7 +529,6 @@
                     .then(function (config) {
                         document.querySelector('#globalEnabledDefault').checked = config.Enabled;
                         document.querySelector('#globalAllowUserOverride').checked = config.AllowUserOverride;
-                        document.querySelector('#hideWatchedItems').checked = config.HideWatchedItems || false;
                         document.querySelector('[data-id=txtLibreTranslateUrl]').value = config.LibreTranslateUrl;
                         document.querySelector('[data-id=txtLibreTranslateApiKey]').value = config.LibreTranslateApiKey;
                         document.querySelector('[data-id=txtJellyseerrUrl]').value = config.JellyseerrUrl;
@@ -561,7 +573,8 @@
                                         LowerLimit: 1,
                                         UpperLimit: sectionType.Limit,
                                         ViewMode: sectionType.ViewMode,
-                                        OrderIndex: 999
+                                        OrderIndex: 999,
+                                        HideWatchedItems: false
                                     };
                                 }
                                 addSectionSetting(sectionConfig, sectionType);

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/BecauseYouWatchedSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/BecauseYouWatchedSection.cs
@@ -135,6 +135,11 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
 
 			BaseItem? item = LibraryManager.GetItemById(Guid.Parse(payload.AdditionalData ?? Guid.Empty.ToString()));
 
+            var config = HomeScreenSectionsPlugin.Instance?.Configuration;
+			var sectionSettings = config?.SectionSettings.FirstOrDefault(x => x.SectionId == Section);
+            // If HideWatchedItems is enabled for this section, set isPlayed to false to hide watched items; otherwise, include all.
+            bool? isPlayed = sectionSettings?.HideWatchedItems == true ? false : null;
+
 			IReadOnlyList<BaseItem>? similar = LibraryManager.GetItemList(new InternalItemsQuery(UserManager.GetUserById(payload.UserId))
 			{
 				Limit = 8,
@@ -144,7 +149,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
 				},
 				IsMovie = true,
 				User = user,
-				IsPlayed = false, // Maybe make this configuable but this is the preferred default behaviour.
+				IsPlayed = isPlayed,
 				EnableGroupByMetadataKey = true,
 				DtoOptions = dtoOptions
 			}.ApplySimilarSettings(item));
@@ -162,7 +167,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
 				Route = Route,
 				Limit = Limit ?? 1,
 				OriginalPayload = OriginalPayload,
-				ViewMode = SectionViewMode.Landscape
+				ViewMode = SectionViewMode.Landscape,
+                AllowHideWatched = true
 			};
 		}
 	}

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/LatestMoviesSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/LatestMoviesSection.cs
@@ -63,8 +63,9 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
             User? user = m_userManager.GetUserById(payload.UserId);
 
             var config = HomeScreenSectionsPlugin.Instance?.Configuration;
-            // If HideWatchedItems is enabled in config, set isPlayed to false to hide watched items; otherwise, include all.
-            bool? isPlayed = config?.HideWatchedItems == true ? false : null;
+            var sectionSettings = config?.SectionSettings.FirstOrDefault(x => x.SectionId == Section);
+            // If HideWatchedItems is enabled for this section, set isPlayed to false to hide watched items; otherwise, include all.
+            bool? isPlayed = sectionSettings?.HideWatchedItems == true ? false : null;
 
             IReadOnlyList<BaseItem> latestMovies = m_libraryManager.GetItemList(new InternalItemsQuery(user)
             {
@@ -133,7 +134,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
                 Route = Route,
                 Limit = Limit ?? 1,
                 OriginalPayload = OriginalPayload,
-                ViewMode = SectionViewMode.Landscape
+                ViewMode = SectionViewMode.Landscape,
+                AllowHideWatched = true
             };
         }
     }

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/LatestShowsSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/LatestShowsSection.cs
@@ -69,8 +69,9 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
             User? user = m_userManager.GetUserById(payload.UserId);
 
             var config = HomeScreenSectionsPlugin.Instance?.Configuration;
-            // If HideWatchedItems is enabled in config, set isPlayed to false to hide watched items; otherwise, include all.
-            bool? isPlayed = config?.HideWatchedItems == true ? false : null;
+            var sectionSettings = config?.SectionSettings.FirstOrDefault(x => x.SectionId == Section);
+            // If HideWatchedItems is enabled for this section, set isPlayed to false to hide watched items; otherwise, include all.
+            bool? isPlayed = sectionSettings?.HideWatchedItems == true ? false : null;
 
             IReadOnlyList<BaseItem> episodes = m_libraryManager.GetItemList(new InternalItemsQuery(user)
             {
@@ -144,7 +145,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
                 Route = Route,
                 Limit = Limit ?? 1,
                 OriginalPayload = OriginalPayload,
-                ViewMode = SectionViewMode.Landscape
+                ViewMode = SectionViewMode.Landscape,
+                AllowHideWatched = true
             };
         }
     }

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/RecentlyAddedMoviesSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/RecentlyAddedMoviesSection.cs
@@ -79,8 +79,9 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
             };
 
             var config = HomeScreenSectionsPlugin.Instance?.Configuration;
-            // If HideWatchedItems is enabled in config, set isPlayed to false to hide watched items; otherwise, include all.
-            bool? isPlayed = config?.HideWatchedItems == true ? false : null;
+            var sectionSettings = config?.SectionSettings.FirstOrDefault(x => x.SectionId == Section);
+            // If HideWatchedItems is enabled for this section, set isPlayed to false to hide watched items; otherwise, include all.
+            bool? isPlayed = sectionSettings?.HideWatchedItems == true ? false : null;
 
             IReadOnlyList<BaseItem> recentlyAddedMovies = m_libraryManager.GetItemList(new InternalItemsQuery(user)
             {
@@ -151,7 +152,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
                 Route = Route,
                 Limit = Limit ?? 1,
                 OriginalPayload = OriginalPayload,
-                ViewMode = SectionViewMode.Landscape
+                ViewMode = SectionViewMode.Landscape,
+                AllowHideWatched = true
             };
         }
     }

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/RecentlyAddedShowsSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/RecentlyAddedShowsSection.cs
@@ -80,8 +80,9 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
             };
 
             var config = HomeScreenSectionsPlugin.Instance?.Configuration;
-            // If HideWatchedItems is enabled in config, set isPlayed to false to hide watched items; otherwise, include all.
-            bool? isPlayed = config?.HideWatchedItems == true ? false : null;
+            var sectionSettings = config?.SectionSettings.FirstOrDefault(x => x.SectionId == Section);
+            // If HideWatchedItems is enabled for this section, set isPlayed to false to hide watched items; otherwise, include all.
+            bool? isPlayed = sectionSettings?.HideWatchedItems == true ? false : null;
 
             IReadOnlyList<BaseItem> episodes = m_libraryManager.GetItemList(new InternalItemsQuery(user)
             {
@@ -156,7 +157,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
                 Route = Route,
                 Limit = Limit ?? 1,
                 OriginalPayload = OriginalPayload,
-                ViewMode = SectionViewMode.Landscape
+                ViewMode = SectionViewMode.Landscape,
+                AllowHideWatched = true
             };
         }
     }

--- a/src/Jellyfin.Plugin.HomeScreenSections/Library/IHomeScreenManager.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Library/IHomeScreenManager.cs
@@ -69,6 +69,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.Library
         public object? OriginalPayload { get; set; }
         
         public bool AllowViewModeChange { get; set; } = true;
+
+        public bool AllowHideWatched { get; set; } = false;
     }
 
     public class ModularHomeUserSettings


### PR DESCRIPTION
closes https://github.com/IAmParadox27/jellyfin-plugin-home-sections/issues/88

I noticed this comment:
https://github.com/IAmParadox27/jellyfin-plugin-home-sections/blob/4ddf4e21b77b065cac3eaf585daf787c30b41b8e/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/BecauseYouWatchedSection.cs#L147

would you like me to have the because you watched section be configured by this new hide watched items option?

<img width="201" height="71" alt="image" src="https://github.com/user-attachments/assets/75286ddc-8e44-4a43-bbfa-f26d8d5cbe67" />
