### PR TITLE
fix: make jellyseerr api key input box of type password

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
@@ -176,7 +176,7 @@
                                     <div class="fieldDescription">URL for Jellyseerr to use for Discover sections.</div>
                                 </div>
                                 <div class="inputContainer">
-                                    <input is="emby-input" type="text" data-id="txtJellyseerrApiKey" required="required" label="Jellyseerr API Key" />
+                                    <input is="emby-input" type="password" data-id="txtJellyseerrApiKey" required="required" label="Jellyseerr API Key" />
                                     <div class="fieldDescription">API Key for Jellyseerr instance.</div>
                                 </div>
                                 <div class="inputContainer">


### PR DESCRIPTION
closes https://github.com/IAmParadox27/jellyfin-plugin-home-sections/issues/87