### PR TITLE
feat: Add support for separate internal and external Jellyseerr URLs

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/PluginConfiguration.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/PluginConfiguration.cs
@@ -14,6 +14,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.Configuration
         
         public string? JellyseerrUrl { get; set; } = "";
 
+        public string? JellyseerrExternalUrl { get; set; } = "";
+
         public string? JellyseerrApiKey { get; set; } = "";
         
         public string? JellyseerrPreferredLanguages { get; set; } = "en";

--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
@@ -172,8 +172,12 @@
                             <summary style="cursor: pointer; font-weight: bold;">Jellyseerr</summary>
                              <div style="padding-top: 1em;">
                                 <div class="inputContainer">
-                                    <input is="emby-input" type="text" data-id="txtJellyseerrUrl" label="Jellyseerr URL" />
-                                    <div class="fieldDescription">URL for Jellyseerr to use for Discover sections.</div>
+                                    <input is="emby-input" type="text" data-id="txtJellyseerrUrl" label="Jellyseerr URL (Internal)" />
+                                    <div class="fieldDescription">Internal URL for Jellyseerr to use for API requests from the plugin backend.</div>
+                                </div>
+                                <div class="inputContainer">
+                                    <input is="emby-input" type="text" data-id="txtJellyseerrExternalUrl" label="Jellyseerr URL (External)" />
+                                    <div class="fieldDescription">External URL for Jellyseerr links in the frontend. Leave empty to use the internal URL.</div>
                                 </div>
                                 <div class="inputContainer">
                                     <input is="emby-input" type="password" data-id="txtJellyseerrApiKey" required="required" label="Jellyseerr API Key" />
@@ -510,6 +514,7 @@
                     LibreTranslateUrl: document.querySelector('[data-id=txtLibreTranslateUrl]').value,
                     LibreTranslateApiKey: document.querySelector('[data-id=txtLibreTranslateApiKey]').value,
                     JellyseerrUrl: document.querySelector('[data-id=txtJellyseerrUrl]').value,
+                    JellyseerrExternalUrl: document.querySelector('[data-id=txtJellyseerrExternalUrl]').value,
                     JellyseerrApiKey: document.querySelector('[data-id=txtJellyseerrApiKey]').value,
                     JellyseerrPreferredLanguages: document.querySelector('[data-id=txtJellyseerrPreferredLanguages]').value,
                     DefaultMoviesLibraryId: document.querySelector('#defaultMoviesLibrary').value,
@@ -558,6 +563,7 @@
                         document.querySelector('[data-id=txtLibreTranslateUrl]').value = config.LibreTranslateUrl;
                         document.querySelector('[data-id=txtLibreTranslateApiKey]').value = config.LibreTranslateApiKey;
                         document.querySelector('[data-id=txtJellyseerrUrl]').value = config.JellyseerrUrl;
+                        document.querySelector('[data-id=txtJellyseerrExternalUrl]').value = config.JellyseerrExternalUrl;
                         document.querySelector('[data-id=txtJellyseerrApiKey]').value = config.JellyseerrApiKey;
                         document.querySelector('[data-id=txtJellyseerrPreferredLanguages]').value = config.JellyseerrPreferredLanguages;
                         

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/DiscoverSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/DiscoverSection.cs
@@ -35,6 +35,10 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
             
             // TODO: Get Jellyseerr Url
             string? jellyseerrUrl = HomeScreenSectionsPlugin.Instance.Configuration.JellyseerrUrl;
+            string? jellyseerrExternalUrl = HomeScreenSectionsPlugin.Instance.Configuration.JellyseerrExternalUrl;
+            
+            // Use external URL for frontend links if configured, otherwise fall back to internal URL
+            string? jellyseerrDisplayUrl = !string.IsNullOrEmpty(jellyseerrExternalUrl) ? jellyseerrExternalUrl : jellyseerrUrl;
 
             if (string.IsNullOrEmpty(jellyseerrUrl))
             {
@@ -97,7 +101,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
                                     SourceType = item.Value<string>("mediaType"),
                                     ProviderIds = new Dictionary<string, string>()
                                     {
-                                        { "JellyseerrRoot", jellyseerrUrl },
+                                        { "JellyseerrRoot", jellyseerrDisplayUrl },
                                         { "Jellyseerr", item.Value<int>("id").ToString() },
                                         { "JellyseerrPoster", item.Value<string>("posterPath") ?? "404" }
                                     },


### PR DESCRIPTION
- Add JellyseerrExternalUrl configuration property
- Update config UI with separate fields for internal and external URLs
- Use internal URL for backend API requests and external URL for frontend links
- Maintains backward compatibility: falls back to internal URL if external not configured