### PR TITLE
fix: Added url encoding for username passed as query param

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/MyRequestsSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/MyRequestsSection.cs
@@ -62,7 +62,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
             client.BaseAddress = new Uri(jellyseerrUrl);
             client.DefaultRequestHeaders.Add("X-Api-Key", HomeScreenSectionsPlugin.Instance.Configuration.JellyseerrApiKey);
             
-            HttpResponseMessage usersResponse = client.GetAsync($"/api/v1/user?q={user.Username}").GetAwaiter().GetResult();
+            HttpResponseMessage usersResponse = client.GetAsync($"/api/v1/user?q={Uri.EscapeDataString(user.Username)}").GetAwaiter().GetResult();
             string userResponseRaw = usersResponse.Content.ReadAsStringAsync().GetAwaiter().GetResult();
             int? jellyseerrUserId = JObject.Parse(userResponseRaw).Value<JArray>("results")?.OfType<JObject>().FirstOrDefault(x => x.Value<string>("jellyfinUsername") == user.Username)?.Value<int>("id");
 


### PR DESCRIPTION
 Avoid errors when username has invalid chars ex. username@example.com