### PR TITLE
fix(#177): allow user to hide watched episodes in ContinueWatchingNextUp section

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/ContinueWatchingNextUpSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/ContinueWatchingNextUpSection.cs
@@ -42,6 +42,14 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
                 returnItems.AddRange(nuResults.Where(x => returnItems.All(y => y.Id != x.Id)));
             }
 
+            // If HideWatchedItems is enabled for this section, filter out watched items
+            var config = HomeScreenSectionsPlugin.Instance?.Configuration;
+            var sectionSettings = config?.SectionSettings.FirstOrDefault(x => x.SectionId == Section);
+            if (sectionSettings?.HideWatchedItems == true)
+            {
+                returnItems = returnItems.Where(x => x.UserData?.Played != true).ToList();
+            }
+
             // For now just returning this data as Continue Watching then Next Up, but we may want to sort this differently in the future
             return new QueryResult<BaseItemDto>(returnItems);
         }
@@ -61,7 +69,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
                 Route = Route,
                 Limit = Limit ?? 1,
                 OriginalPayload = OriginalPayload,
-                ViewMode = SectionViewMode.Landscape
+                ViewMode = SectionViewMode.Landscape,
+                AllowHideWatched = true
             };
         }
     }


### PR DESCRIPTION
closes #177

not filtering at the (more efficient) database level like other sections because we're combining two sections here. we could instead filter at the database level on the next up section and allow the hide watched setting for this section to also change the next up section's hide watched setting.. but i'm not sure as that feels a little obtuse