### PR TITLE
fix: sort combined next up/continue watching section by last played date

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/ContinueWatchingNextUpSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/ContinueWatchingNextUpSection.cs
@@ -41,7 +41,17 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
         public QueryResult<BaseItemDto> GetResults(HomeScreenSectionPayload payload, IQueryCollection queryCollection)
         {
             IReadOnlyList<BaseItemDto>? cwResults = m_continueWatchingSection?.GetResults(payload, queryCollection).Items;
-            IReadOnlyList<BaseItemDto>? nuResults = m_nextUpSection?.GetResults(payload, queryCollection).Items;
+            
+            // Apply default Next Up settings, halves performance impact
+            // Unfortunately we can't get the user's actual Next Up settings, as they're stored in local storage on the client
+            var nuQuery = new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+            {
+                ["UserId"] = queryCollection["UserId"],
+                ["EnableRewatching"] = "false",
+                ["NextUpDateCutoff"] = DateTime.UtcNow.AddDays(-365).ToString("O")
+            };
+            
+            IReadOnlyList<BaseItemDto>? nuResults = m_nextUpSection?.GetResults(payload, new QueryCollection(nuQuery)).Items;
             
             List<BaseItemDto> returnItems = new List<BaseItemDto>();
 


### PR DESCRIPTION
Closes: https://github.com/IAmParadox27/jellyfin-plugin-home-sections/issues/198

Now sorts the section by whatever the user last interacted with, no matter which parent section it comes from.

I had hoped Jellyfin would store LastPlayedDate in UserData for all next up items, but this doesn't seem to be the case for episodes that are next up because the user has finished watching the last episode but not interacted with the next up one at all.
To address this I've used the seriesId and to query the previous episode's LastPlayedDate. 

Also applied the default next up settings (limited to the last 365 days and rewatching disabled) which has halved the performance impact (of the original section, I actually didn't record a difference in performance after enabling sorting :partying_face:)

### Copilot summary:

This pull request introduces improvements to the `ContinueWatchingNextUpSection` logic, focusing on more accurate sorting of items based on user activity and optimizing the retrieval of "Next Up" results. The changes enhance both performance and the relevance of the displayed items by leveraging user data and series history.

Enhancements to item sorting and user data handling:

* Added logic to sort the combined "Continue Watching" and "Next Up" items by the most recent activity, using episode and series `LastPlayedDate`, with fallback to `DateCreated` when necessary. This ensures users see the most relevant content first.
* Introduced the `BuildSeriesLastPlayedLookup` method to efficiently determine the last played date for series where episode data is missing, improving sorting accuracy for episodes without direct user activity records.
* Added the `GetSortDate` helper method to centralize sorting logic based on user and series activity.

Performance and query improvements:

* Modified the retrieval of "Next Up" items to use default settings server-side, halving performance impact and bypassing client-side local storage limitations.

Dependency and constructor updates:

* Updated the constructor to inject `ILibraryManager`, `IUserManager`, and `IUserDataManager` dependencies, enabling access to user and library data required for the new sorting logic. [[1]](diffhunk://#diff-d3dbb7caa9de0225e1ab41ca840095c48ba0da6acaed9bf0aa50bcffe173565fR4-R6) [[2]](diffhunk://#diff-d3dbb7caa9de0225e1ab41ca840095c48ba0da6acaed9bf0aa50bcffe173565fR24-R54)