### PR TITLE
fix(lazy-load): prevent early return when sections are still processing

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/Services/HomeScreenSectionService.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Services/HomeScreenSectionService.cs
@@ -72,7 +72,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.Services
             }
             
             sectionsToReturn = sectionsToReturn.Skip((page - 1) * pageSize).Take(pageSize).ToList();
-            if (isComplete || sectionsToReturn.Count == pageSize)
+            if ((isComplete && !userSectionsData.SectionsInProgress.Any()) || sectionsToReturn.Count == pageSize)
             {
                 return sectionsToReturn
                     .Select(x => SectionToInfo(x.Section, x.ConfiguredOrder, language))


### PR DESCRIPTION
## Summary

Fixes a race condition in `GetCachedSectionsForUser()` where sections with higher `OrderIndex` values (e.g. `BecauseYouWatched`, `Genre` at index 999) are never loaded when Lazy Load is enabled.

The `isComplete` flag only checked whether existing keys in `OrderedSections` were cohesive — but not whether sections were still being processed in the background. When faster sections (low OrderIndex) finished before slower ones, the method returned early and the monitor loop never reached the higher indices.

The fix adds a check that `SectionsInProgress` is empty before considering the data complete.

Fixes #221. Relates to #153.

## Test plan

- [x] Enabled Lazy Load with sections at OrderIndex 1–8 and 999
- [x] Verified that `BecauseYouWatched` and `Genre` now load (via scroll on page 2)
- [x] Verified Network tab: Page 1 returns correct `TotalRecordCount`, Page 2 loads remaining sections
- [x] Verified that disabling Lazy Load still works as before

Analyzed and developed with AI assistance (Claude Code / Opus 4.6).

##Screenshots

<img width="824" height="459" alt="lazy-load5" src="https://github.com/user-attachments/assets/88e2a176-4fda-4533-b37d-0bae2b8042d8" />

<img width="772" height="1358" alt="dashboard-after-fix" src="https://github.com/user-attachments/assets/e345d7e8-4dea-4aef-bff4-d2f0e25848bf" />
