### PR TITLE
Filter out library based on user preferences

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/Helpers/MiscExtensions.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Helpers/MiscExtensions.cs
@@ -1,4 +1,6 @@
 using System.Reflection;
+using Jellyfin.Data;
+using Jellyfin.Database.Implementations.Enums;
 using MediaBrowser.Controller.Collections;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
@@ -21,7 +23,15 @@ public static class MiscExtensions
 
     public static VirtualFolderInfo[] FilterToUserPermitted(this IEnumerable<VirtualFolderInfo> folders, ILibraryManager libraryManager, User? user)
     {
-        return folders
+        IEnumerable<VirtualFolderInfo> filtered = folders;
+
+        if (user != null)
+        {
+            Guid[] latestItemExcludes = user.GetPreferenceValues<Guid>(PreferenceKind.LatestItemExcludes);
+            filtered = filtered.Where(x => !latestItemExcludes.Contains(Guid.Parse(x.ItemId)));
+        }
+
+        return filtered
             .Where(x =>
             {
                 IEnumerable<BaseItem> items = libraryManager.GetItemList(new InternalItemsQuery(user)


### PR DESCRIPTION
Respects the per-user library visibility setting ("Display in home screen sections such as 'Recently Added Media' and 'Continue Watching'") found under User → Home. Libraries unchecked by a user are now correctly excluded from all plugin-provided home sections.