### PR TITLE
Fix My Requests row showing the whole library when the user has no requests

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/MyRequestsSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/MyRequestsSection.cs
@@ -87,6 +87,18 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
 
                 IEnumerable<string?>? jellyfinItemIds = presentRequestedMedia?.Select(x => x.Value<string>("jellyfinMediaId"));
 
+                // Only show items this user actually requested. Without this guard, a user with no
+                // requests produces an empty ItemIds array, which Jellyfin's InternalItemsQuery treats
+                // as "no filter" and returns the entire (recently-added) library for that ParentId.
+                Guid[] requestedItemIds = jellyfinItemIds?
+                    .Where(y => !string.IsNullOrEmpty(y))
+                    .Select(y => Guid.Parse(y!))
+                    .ToArray() ?? Array.Empty<Guid>();
+                if (requestedItemIds.Length == 0)
+                {
+                    return new QueryResult<BaseItemDto>();
+                }
+
                 var config = HomeScreenSectionsPlugin.Instance?.Configuration;
                 var sectionSettings = config?.SectionSettings.FirstOrDefault(x => x.SectionId == Section);
                 bool hideWatchedItems = sectionSettings?.HideWatchedItems == true;
@@ -95,7 +107,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
                 {
                     return m_libraryManager.GetItemList(new InternalItemsQuery(user)
                     {
-                        ItemIds = jellyfinItemIds?.Select(y => Guid.Parse(y ?? Guid.Empty.ToString()))?.ToArray() ?? Array.Empty<Guid>(),
+                        ItemIds = requestedItemIds,
                         Recursive = true,
                         EnableTotalRecordCount = false,
                         ParentId = Guid.Parse(x.ItemId ?? Guid.Empty.ToString())


### PR DESCRIPTION
## Problem

`MyRequestsSection.GetResults` builds the query like this:

```csharp
ItemIds = jellyfinItemIds?.Select(y => Guid.Parse(y ?? Guid.Empty.ToString()))?.ToArray() ?? Array.Empty<Guid>(),
```

When the signed-in user has **no** Jellyseerr requests, `jellyfinItemIds` is empty, so `ItemIds`
becomes `Array.Empty<Guid>()`. Jellyfin's `InternalItemsQuery` treats an empty `ItemIds` as
"no id filter", so the query returns the **entire library** under the `ParentId` (i.e. recently-added
items) instead of nothing. The **My Requests** row then shows unrelated content for any user who
hasn't requested anything — which is most non-admin users.

(The old expression also mapped null ids to `Guid.Empty` via `Guid.Parse(y ?? Guid.Empty.ToString())`,
which would inject `Guid.Empty` into the filter.)

## Fix

Parse the requested ids once (skipping null/empty), and if there are none, return an empty
`QueryResult<BaseItemDto>` so the section is genuinely empty. Users who do have requests are
unaffected (same items as before).

```csharp
Guid[] requestedItemIds = jellyfinItemIds?
    .Where(y => !string.IsNullOrEmpty(y))
    .Select(y => Guid.Parse(y!))
    .ToArray() ?? Array.Empty<Guid>();
if (requestedItemIds.Length == 0)
{
    return new QueryResult<BaseItemDto>();
}
```

…and the query then uses `ItemIds = requestedItemIds`.

## Testing

- Builds clean against Jellyfin 10.11.11 (`dotnet build -c Release -p:JellyfinVersion=10.11.11`).
- Verified on a live 10.11.11 server via `GET /HomeScreen/Section/MyJellyseerrRequests?userId=…`:
  users with 0 requests now return an empty result; a user with requests returns exactly their
  requested, in-library items.
