### PR TITLE
feat: Filter upcoming sections by user library access

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/PluginConfiguration.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/PluginConfiguration.cs
@@ -45,6 +45,9 @@ namespace Jellyfin.Plugin.HomeScreenSections.Configuration
         public string DateFormat { get; set; } = "YYYY/MM/DD";
 
         public string DateDelimiter { get; set; } = "/";
+
+        public bool FilterUpcomingByLibraryAccess { get; set; } = true;
+
         public bool DeveloperMode { get; set; } = false;
 
         public int CacheBustCounter { get; set; } = 0;

--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
@@ -187,9 +187,9 @@
                                 <div class="checkboxContainer checkboxContainer-withDescription" style="margin-top: 1em;">
                                     <label class="emby-checkbox-label">
                                         <input id="filterUpcomingByLibraryAccess" type="checkbox" is="emby-checkbox" class="emby-checkbox">
-                                        <span>Filter Upcoming Sections by Library Access</span>
+                                        <span data-i18n="AdminFilterUpcomingByLibraryAccess">Filter Upcoming Sections by Library Access</span>
                                     </label>
-                                    <div class="fieldDescription">When enabled, upcoming items are hidden from users who don't have access to the library the items belong to.</br> Relies on matching the *arr root folder path against your Jellyfin library paths, so this only works if Jellyfin and your *arr instances use the same paths.</div>
+                                    <div class="fieldDescription" data-i18n="AdminFilterUpcomingByLibraryAccessDesc">When enabled, upcoming items are hidden from users who don't have access to the library the items belong to. Relies on matching the *arr root folder path against your Jellyfin library paths, so this only works if Jellyfin and your *arr instances use the same paths.</div>
                                 </div>
                             </div>
                         </details>

--- a/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Configuration/config.html
@@ -184,6 +184,13 @@
                                     <input is="emby-input" type="password" data-id="txtReadarrApiKey" data-i18n-label="AdminReadarrApiKey" label="Readarr API Key" />
                                     <div class="fieldDescription" data-i18n="AdminReadarrApiKeyDesc">API Key for Readarr instance.</div>
                                 </div>
+                                <div class="checkboxContainer checkboxContainer-withDescription" style="margin-top: 1em;">
+                                    <label class="emby-checkbox-label">
+                                        <input id="filterUpcomingByLibraryAccess" type="checkbox" is="emby-checkbox" class="emby-checkbox">
+                                        <span>Filter Upcoming Sections by Library Access</span>
+                                    </label>
+                                    <div class="fieldDescription">When enabled, upcoming items are hidden from users who don't have access to the library the items belong to.</br> Relies on matching the *arr root folder path against your Jellyfin library paths, so this only works if Jellyfin and your *arr instances use the same paths.</div>
+                                </div>
                             </div>
                         </details>
                         <details style="margin-bottom: 1em;">
@@ -667,6 +674,7 @@
                     ])),
                     DateFormat: document.querySelector('#dateFormat').value,
                     DateDelimiter: document.querySelector('#dateDelimiter').value,
+                    FilterUpcomingByLibraryAccess: document.querySelector('#filterUpcomingByLibraryAccess').checked,
                     DeveloperMode: document.querySelector('#globalDeveloperMode').checked,
                     CacheTimeoutSeconds: document.querySelector('[data-id=txtCacheTimeoutSeconds]').value || 86400,
                     MaxImageCacheEntries: parseInt(document.querySelector('[data-id=txtMaxImageCacheEntries]').value) || 10000,
@@ -716,6 +724,7 @@
                         });
                         document.querySelector('#dateFormat').value = config.DateFormat || 'YYYY/MM/DD';
                         document.querySelector('#dateDelimiter').value = config.DateDelimiter || '/';
+                        document.querySelector('#filterUpcomingByLibraryAccess').checked = config.FilterUpcomingByLibraryAccess !== false;
 
                         document.querySelector('#globalStreamyfinHomeOverride').checked = config.OverrideStreamyfinHome;
                         document.querySelector('#globalDeveloperMode').checked = config.DeveloperMode;

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/Upcoming/UpcomingBooksSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/Upcoming/UpcomingBooksSection.cs
@@ -15,8 +15,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections.Upcoming
         
         public override string? DisplayText { get; set; } = "Upcoming Books";
 
-        public UpcomingBooksSection(IUserManager userManager, IDtoService dtoService, ArrApiService arrApiService, ImageCacheService imageCacheService, ILogger<UpcomingBooksSection> logger)
-            : base(userManager, dtoService, arrApiService, imageCacheService, logger)
+        public UpcomingBooksSection(IUserManager userManager, ILibraryManager libraryManager, IDtoService dtoService, ArrApiService arrApiService, ImageCacheService imageCacheService, ILogger<UpcomingBooksSection> logger)
+            : base(userManager, libraryManager, dtoService, arrApiService, imageCacheService, logger)
         {
         }
 
@@ -41,6 +41,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections.Upcoming
                 .Where(item => item.Monitored && !item.HasFile && item.ReleaseDate.HasValue)
                 .OrderBy(item => item.ReleaseDate);
         }
+
+        protected override string? GetItemPath(ReadarrCalendarDto item) => item.Author?.Path;
 
         protected override string GetFallbackCoverUrl(ReadarrCalendarDto missingItem)
         {
@@ -87,7 +89,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections.Upcoming
 
         public override IEnumerable<IHomeScreenSection> CreateInstances(Guid? userId, int instanceCount)
         {
-            yield return new UpcomingBooksSection(UserManager, DtoService, ArrApiService, ImageCacheService, (ILogger<UpcomingBooksSection>)Logger)
+            yield return new UpcomingBooksSection(UserManager, LibraryManager, DtoService, ArrApiService, ImageCacheService, (ILogger<UpcomingBooksSection>)Logger)
             {
                 DisplayText = DisplayText,
                 AdditionalData = AdditionalData,

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/Upcoming/UpcomingMoviesSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/Upcoming/UpcomingMoviesSection.cs
@@ -15,8 +15,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections.Upcoming
         
         public override string? DisplayText { get; set; } = "Upcoming Movies";
 
-        public UpcomingMoviesSection(IUserManager userManager, IDtoService dtoService, ArrApiService arrApiService, ImageCacheService imageCacheService, ILogger<UpcomingMoviesSection> logger)
-            : base(userManager, dtoService, arrApiService, imageCacheService, logger)
+        public UpcomingMoviesSection(IUserManager userManager, ILibraryManager libraryManager, IDtoService dtoService, ArrApiService arrApiService, ImageCacheService imageCacheService, ILogger<UpcomingMoviesSection> logger)
+            : base(userManager, libraryManager, dtoService, arrApiService, imageCacheService, logger)
         {
         }
 
@@ -64,6 +64,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections.Upcoming
                 })
                 .OrderBy(item => GetEarliestReleaseDate(item, config));
         }
+
+        protected override string? GetItemPath(RadarrCalendarDto item) => item.Path;
 
         protected override string GetFallbackCoverUrl(RadarrCalendarDto missingItem)
         {
@@ -115,7 +117,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections.Upcoming
 
         public override IEnumerable<IHomeScreenSection> CreateInstances(Guid? userId, int instanceCount)
         {
-            yield return new UpcomingMoviesSection(UserManager, DtoService, ArrApiService, ImageCacheService, (ILogger<UpcomingMoviesSection>)Logger)
+            yield return new UpcomingMoviesSection(UserManager, LibraryManager, DtoService, ArrApiService, ImageCacheService, (ILogger<UpcomingMoviesSection>)Logger)
             {
                 DisplayText = DisplayText,
                 AdditionalData = AdditionalData,

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/Upcoming/UpcomingMusicSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/Upcoming/UpcomingMusicSection.cs
@@ -15,8 +15,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections.Upcoming
         
         public override string? DisplayText { get; set; } = "Upcoming Music";
 
-        public UpcomingMusicSection(IUserManager userManager, IDtoService dtoService, ArrApiService arrApiService, ImageCacheService imageCacheService, ILogger<UpcomingMusicSection> logger)
-            : base(userManager, dtoService, arrApiService, imageCacheService, logger)
+        public UpcomingMusicSection(IUserManager userManager, ILibraryManager libraryManager, IDtoService dtoService, ArrApiService arrApiService, ImageCacheService imageCacheService, ILogger<UpcomingMusicSection> logger)
+            : base(userManager, libraryManager, dtoService, arrApiService, imageCacheService, logger)
         {
         }
 
@@ -41,6 +41,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections.Upcoming
                 .Where(item => item.Monitored && !item.HasFile && item.ReleaseDate.HasValue)
                 .OrderBy(item => item.ReleaseDate);
         }
+
+        protected override string? GetItemPath(LidarrCalendarDto item) => item.Artist?.Path;
 
         protected override string GetFallbackCoverUrl(LidarrCalendarDto missingItem)
         {
@@ -88,7 +90,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections.Upcoming
 
         public override IEnumerable<IHomeScreenSection> CreateInstances(Guid? userId, int instanceCount)
         {
-            yield return new UpcomingMusicSection(UserManager, DtoService, ArrApiService, ImageCacheService, (ILogger<UpcomingMusicSection>)Logger)
+            yield return new UpcomingMusicSection(UserManager, LibraryManager, DtoService, ArrApiService, ImageCacheService, (ILogger<UpcomingMusicSection>)Logger)
             {
                 DisplayText = DisplayText,
                 AdditionalData = AdditionalData,

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/Upcoming/UpcomingShowsSection.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/Upcoming/UpcomingShowsSection.cs
@@ -15,8 +15,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections.Upcoming
         
         public override string? DisplayText { get; set; } = "Upcoming Shows";
 
-        public UpcomingShowsSection(IUserManager userManager, IDtoService dtoService, ArrApiService arrApiService, ImageCacheService imageCacheService, ILogger<UpcomingShowsSection> logger)
-            : base(userManager, dtoService, arrApiService, imageCacheService, logger)
+        public UpcomingShowsSection(IUserManager userManager, ILibraryManager libraryManager, IDtoService dtoService, ArrApiService arrApiService, ImageCacheService imageCacheService, ILogger<UpcomingShowsSection> logger)
+            : base(userManager, libraryManager, dtoService, arrApiService, imageCacheService, logger)
         {
         }
 
@@ -41,6 +41,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections.Upcoming
                 .Where(item => item.Monitored && !item.HasFile && item.AirDateUtc.HasValue)
                 .OrderBy(item => item.AirDateUtc);
         }
+
+        protected override string? GetItemPath(SonarrCalendarDto item) => item.Series?.Path;
 
         protected override string GetFallbackCoverUrl(SonarrCalendarDto missingItem)
         {
@@ -95,7 +97,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections.Upcoming
 
         public override IEnumerable<IHomeScreenSection> CreateInstances(Guid? userId, int instanceCount)
         {
-            yield return new UpcomingShowsSection(UserManager, DtoService, ArrApiService, ImageCacheService, (ILogger<UpcomingShowsSection>)Logger)
+            yield return new UpcomingShowsSection(UserManager, LibraryManager, DtoService, ArrApiService, ImageCacheService, (ILogger<UpcomingShowsSection>)Logger)
             {
                 DisplayText = DisplayText,
                 AdditionalData = AdditionalData,

--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/UpcomingSectionBase.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/UpcomingSectionBase.cs
@@ -6,6 +6,7 @@ using Jellyfin.Plugin.HomeScreenSections.Services;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Querying;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -22,14 +23,16 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
         public object? OriginalPayload { get; set; } = null;
         
         protected IUserManager UserManager { get; }
+        protected ILibraryManager LibraryManager { get; }
         protected IDtoService DtoService { get; }
         protected ArrApiService ArrApiService { get; }
         protected ImageCacheService ImageCacheService { get; }
         protected ILogger Logger { get; }
 
-        protected UpcomingSectionBase(IUserManager userManager, IDtoService dtoService, ArrApiService arrApiService, ImageCacheService imageCacheService, ILogger logger)
+        protected UpcomingSectionBase(IUserManager userManager, ILibraryManager libraryManager, IDtoService dtoService, ArrApiService arrApiService, ImageCacheService imageCacheService, ILogger logger)
         {
             UserManager = userManager;
+            LibraryManager = libraryManager;
             DtoService = dtoService;
             ArrApiService = arrApiService;
             ImageCacheService = imageCacheService;
@@ -71,6 +74,11 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
 
                 T[] upcomingItems = [.. FilterAndSortItems(calendarItems).Take(16)];
 
+                if (config.FilterUpcomingByLibraryAccess)
+                {
+                    upcomingItems = FilterByLibraryAccess(upcomingItems, payload.UserId);
+                }
+
                 Logger.LogDebug("Found {Count} upcoming items after filtering", upcomingItems.Length);
 
                 BaseItemDto[] dtoItems = [.. upcomingItems.Select(item => CreateDto(item, config))];
@@ -82,6 +90,53 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
                 Logger.LogError(ex, "Error fetching {SectionName} from {ServiceName}", GetSectionName(), GetServiceName());
                 return new QueryResult<BaseItemDto>();
             }
+        }
+
+        private T[] FilterByLibraryAccess(T[] items, Guid userId)
+        {
+            User? user = UserManager.GetUserById(userId);
+            if (user == null)
+            {
+                return items;
+            }
+
+            VirtualFolderInfo[] allFolders = [.. LibraryManager.GetVirtualFolders()];
+            if (allFolders.Length == 0)
+            {
+                return items;
+            }
+
+            VirtualFolderInfo[] permittedFolders = allFolders.FilterToUserPermitted(LibraryManager, user);
+
+            string[] allLocations = [.. allFolders.SelectMany(folder => folder.Locations)];
+            string[] permittedLocations = [.. permittedFolders.SelectMany(folder => folder.Locations)];
+
+            return [.. items.Where(item => IsItemAccessible(GetItemPath(item), allLocations, permittedLocations))];
+        }
+
+        private static bool IsItemAccessible(string? itemPath, string[] allLocations, string[] permittedLocations)
+        {
+            if (string.IsNullOrEmpty(itemPath))
+            {
+                return true;
+            }
+
+            string normalizedItemPath = NormalizePath(itemPath);
+
+            // The *arr instance may be using a different mount point/path mapping than Jellyfin,
+            // in which case we can't tell which library the item would belong to, so default to showing it.
+            bool matchesKnownLibrary = allLocations.Any(location => normalizedItemPath.StartsWith(NormalizePath(location), StringComparison.OrdinalIgnoreCase));
+            if (!matchesKnownLibrary)
+            {
+                return true;
+            }
+
+            return permittedLocations.Any(location => normalizedItemPath.StartsWith(NormalizePath(location), StringComparison.OrdinalIgnoreCase));
+        }
+
+        private static string NormalizePath(string path)
+        {
+            return path.Replace('\\', '/').TrimEnd('/');
         }
 
         protected string CalculateCountdown(DateTime releaseDate, PluginConfiguration config)
@@ -135,6 +190,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections
         protected abstract (int value, TimeframeUnit unit) GetTimeframeConfiguration(PluginConfiguration config);
         protected abstract T[] GetCalendarItems(DateTime startDate, DateTime endDate);
         protected abstract IOrderedEnumerable<T> FilterAndSortItems(T[] items);
+        protected abstract string? GetItemPath(T item);
         protected abstract BaseItemDto CreateDto(T item, PluginConfiguration config);
         protected abstract string GetServiceName();
         protected abstract string GetSectionName();

--- a/src/Jellyfin.Plugin.HomeScreenSections/Model/Dto/LidarrCalendarDto.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Model/Dto/LidarrCalendarDto.cs
@@ -24,6 +24,9 @@ namespace Jellyfin.Plugin.HomeScreenSections.Model.Dto
     {
         [JsonPropertyName("artistName")]
         public string? ArtistName { get; set; }
+
+        [JsonPropertyName("path")]
+        public string? Path { get; set; }
     }
 
     public class LidarrStatisticsDto

--- a/src/Jellyfin.Plugin.HomeScreenSections/Model/Dto/RadarrCalendarDto.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Model/Dto/RadarrCalendarDto.cs
@@ -18,5 +18,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.Model.Dto
 
         [JsonPropertyName("hasFile")]
         public bool HasFile { get; set; }
+
+        [JsonPropertyName("path")]
+        public string? Path { get; set; }
     }
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/Model/Dto/ReadarrCalendarDto.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Model/Dto/ReadarrCalendarDto.cs
@@ -24,6 +24,9 @@ namespace Jellyfin.Plugin.HomeScreenSections.Model.Dto
     {
         [JsonPropertyName("authorName")]
         public string? AuthorName { get; set; }
+
+        [JsonPropertyName("path")]
+        public string? Path { get; set; }
     }
 
     public class ReadarrStatisticsDto

--- a/src/Jellyfin.Plugin.HomeScreenSections/Model/Dto/SonarrCalendarDto.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Model/Dto/SonarrCalendarDto.cs
@@ -33,5 +33,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.Model.Dto
 
         [JsonPropertyName("id")]
         public int Id { get; set; }
+
+        [JsonPropertyName("path")]
+        public string? Path { get; set; }
     }
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/_Localization/en.json
+++ b/src/Jellyfin.Plugin.HomeScreenSections/_Localization/en.json
@@ -118,6 +118,8 @@
   "AdminReadarrUrlDesc": "Complete URL for Readarr to use for upcoming books sections.",
   "AdminReadarrApiKey": "Readarr API Key",
   "AdminReadarrApiKeyDesc": "API Key for Readarr instance.",
+  "AdminFilterUpcomingByLibraryAccess": "Filter Upcoming Sections by Library Access",
+  "AdminFilterUpcomingByLibraryAccessDesc": "When enabled, upcoming items are hidden from users who don't have access to the library the items belong to. Relies on matching the *arr root folder path against your Jellyfin library paths, so this only works if Jellyfin and your *arr instances use the same paths.",
 
   "AdminLibreTranslate": "LibreTranslate",
   "AdminLibreTranslateUrl": "LibreTranslate URL",


### PR DESCRIPTION
Hides upcoming movies/shows/music/books from users who don't have access to the library they'd be imported into, matching each item's *arr root folder path against the user's permitted Jellyfin library paths. Configurable via "Filter Upcoming Sections by Library Access" (default on). Similar to Jellyfin-Enhanced's calendar filtering for issue #214

Fixes #214