### PR TITLE
Fix 10.10.7 builds: version-split SkiaSharp dependency

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/Helpers/MiscExtensions.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Helpers/MiscExtensions.cs
@@ -1,6 +1,5 @@
 using System.Reflection;
 using Jellyfin.Data;
-using Jellyfin.Database.Implementations.Enums;
 using MediaBrowser.Controller.Collections;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;

--- a/src/Jellyfin.Plugin.HomeScreenSections/Jellyfin.Plugin.HomeScreenSections.csproj
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Jellyfin.Plugin.HomeScreenSections.csproj
@@ -30,7 +30,8 @@
       <PackageReference Include="Jellyfin.Controller" Version="$(JellyfinNugetVersion)" />
       <PackageReference Include="Jellyfin.Extensions" Version="$(JellyfinNugetVersion)" />
       <PackageReference Include="Lib.Harmony" Version="2.4.0" GeneratePathProperty="true" />
-      <PackageReference Include="SkiaSharp" Version="3.116.1" />
+      <PackageReference Include="SkiaSharp" Version="2.88.9" Condition="'$(JellyfinVersion)' == '10.10.7'" />
+      <PackageReference Include="SkiaSharp" Version="3.116.1" Condition="$(JellyfinVersion.StartsWith('10.11'))" />
     </ItemGroup>
     
     <!-- 10.10.7 Specific Code from non 10.10.7 builds -->

--- a/src/Jellyfin.Plugin.HomeScreenSections/JellyfinVersionSpecific/10.10.7/ExtensionsHelper.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/JellyfinVersionSpecific/10.10.7/ExtensionsHelper.cs
@@ -1,4 +1,5 @@
 ﻿using MediaBrowser.Controller.Entities;
+using SkiaSharp;
 
 namespace Jellyfin.Plugin.HomeScreenSections.JellyfinVersionSpecific
 {
@@ -7,6 +8,11 @@ namespace Jellyfin.Plugin.HomeScreenSections.JellyfinVersionSpecific
         public static bool IsPlayedVersionSpecific(this BaseItem item, User user)
         {
             return item.IsPlayed(user);
+        }
+
+        public static SKBitmap? ResizeVersionSpecific(this SKBitmap bitmap, SKImageInfo info)
+        {
+            return bitmap.Resize(info, SKFilterQuality.High);
         }
     }
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/JellyfinVersionSpecific/10.11/ExtensionsHelper.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/JellyfinVersionSpecific/10.11/ExtensionsHelper.cs
@@ -1,4 +1,5 @@
 ﻿using MediaBrowser.Controller.Entities;
+using SkiaSharp;
 
 namespace Jellyfin.Plugin.HomeScreenSections.JellyfinVersionSpecific
 {
@@ -7,6 +8,11 @@ namespace Jellyfin.Plugin.HomeScreenSections.JellyfinVersionSpecific
         public static bool IsPlayedVersionSpecific(this BaseItem item, User user)
         {
             return item.IsPlayed(user, null);
+        }
+
+        public static SKBitmap? ResizeVersionSpecific(this SKBitmap bitmap, SKImageInfo info)
+        {
+            return bitmap.Resize(info, SKSamplingOptions.Default);
         }
     }
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/Services/ImageCacheService.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Services/ImageCacheService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text;
+using Jellyfin.Plugin.HomeScreenSections.JellyfinVersionSpecific;
 using Jellyfin.Plugin.HomeScreenSections.Model.Dto;
 using MediaBrowser.Common.Configuration;
 using Microsoft.Extensions.Logging;
@@ -301,9 +302,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.Services
             int newWidth = maxWidth;
             int newHeight = (int)((float)originalBitmap.Height / originalBitmap.Width * newWidth);
             
-            SKBitmap? resizedBitmap = originalBitmap.Resize(
-                new SKImageInfo(newWidth, newHeight), 
-                SKSamplingOptions.Default);
+            SKBitmap? resizedBitmap = originalBitmap.ResizeVersionSpecific(
+                new SKImageInfo(newWidth, newHeight));
             
             if (resizedBitmap == null)
             {


### PR DESCRIPTION
Fixes #181

The 10.10.7 build ships with SkiaSharp 3.116.1 but Jellyfin 10.10.7 only bundles 2.88.9, so every image op throws FileNotFoundException and home screen artwork dies. This makes the SkiaSharp reference conditional on JellyfinVersion (2.88.9 for 10.10.7, 3.116.1 for 10.11) and moves the one Skia-3-only call (SKSamplingOptions in ImageCacheService.ResizeImage) into ResizeVersionSpecific extensions in the JellyfinVersionSpecific folders, same way ContinueWatchingSection does it. The 2.88 side uses SKFilterQuality.High instead.

Also had to drop `using Jellyfin.Database.Implementations.Enums;` from MiscExtensions - that namespace doesn't exist on 10.10.7 so the variant didn't even compile. The per-version GlobalUsings already cover PreferenceKind.

Checked deps.json on both builds after - 10.10.7 pulls 2.88.9, 10.11.5 still pulls 3.116.1. No manifest changes needed, the existing targetAbi tag just becomes accurate.