### PR TITLE
fix: prevent scroll listener leak on home revisits

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/Controllers/loadSections.js
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Controllers/loadSections.js
@@ -408,15 +408,20 @@
                 PageHash: uuidv4()
             };
             
-            // Setup the scrolly event
+            // Setup the scrolly event (replace any prior handler so SPA revisits
+            // to home do not accumulate scroll listeners).
             window.HssPageCache = {
                 elem: elem,
                 apiClient: apiClient,
                 user: user,
                 userSettings: userSettings
             };
-            
-            window.addEventListener('scroll', function () {
+
+            if (window.HssScrollHandler) {
+                window.removeEventListener('scroll', window.HssScrollHandler);
+            }
+
+            window.HssScrollHandler = function () {
                 var scrollPosition = window.scrollY + window.innerHeight;
                 var windowHeight = getDocHeight();
                 
@@ -460,7 +465,9 @@
                         D.body.clientHeight, D.documentElement.clientHeight
                     );
                 }
-            });
+            };
+
+            window.addEventListener('scroll', window.HssScrollHandler);
         }
         
         var getSectionsData = {


### PR DESCRIPTION
﻿## Summary
- Remove any existing window.HssScrollHandler before registering a new scroll listener
- Prevents progressive homepage slowdowns from stacked listeners after SPA navigations back to home

Closes #242

## Test plan
- [ ] Open home, navigate away, return home repeatedly
- [ ] Confirm only one scroll listener remains (no progressive lag)
