### PR TITLE
fix: guard empty SectionSettings Max in CacheSectionsForUser

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/Services/HomeScreenSectionService.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Services/HomeScreenSectionService.cs
@@ -159,7 +159,14 @@ namespace Jellyfin.Plugin.HomeScreenSections.Services
 
             List<IHomeScreenSection> sectionTypes = m_homeScreenManager.GetSectionTypes().Where(x => settings?.EnabledSections.Contains(x.Section ?? string.Empty) ?? false).ToList();
 
-            IGrouping<int, SectionSettings>[] groupedOrderedSections = HomeScreenSectionsPlugin.Instance.Configuration.SectionSettings
+            // SectionSettings defaults to empty; Max() on empty throws and can take down the
+            // process when this runs on the unhandled MonitorLiveUpdatedSectionsForUser thread
+            // (see #247). Guard both the source sequence and MaxOrderIndex.
+            IEnumerable<SectionSettings> sectionSettings =
+                HomeScreenSectionsPlugin.Instance?.Configuration.SectionSettings
+                ?? Array.Empty<SectionSettings>();
+
+            IGrouping<int, SectionSettings>[] groupedOrderedSections = sectionSettings
                 .OrderBy(x => x.OrderIndex)
                 .GroupBy(x => x.OrderIndex)
                 .ToArray();
@@ -170,7 +177,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.Services
                 userSectionsData = new UserSectionsData()
                 {
                     UserId = userId,
-                    MaxOrderIndex = groupedOrderedSections.Max(x => x.Key)
+                    MaxOrderIndex = groupedOrderedSections.Select(x => x.Key).DefaultIfEmpty(0).Max()
                 };
                 
                 m_dataCache.Cache.TryAdd(pageHash.Value, userSectionsData);


### PR DESCRIPTION
## Summary

Guards `CacheSectionsForUser` against an empty global `SectionSettings` list so `.Max()` no longer throws.

**Closes #247**

## Problem

When `Configuration.SectionSettings` is empty (default / never saved dashboard config) but caching still runs with a `pageHash`:

```csharp
MaxOrderIndex = groupedOrderedSections.Max(x => x.Key)
```

throws `InvalidOperationException: Sequence contains no elements`.

Impacts:
1. `GET /HomeScreen/Sections` → **500** (modular home silently falls back) — #247
2. `MonitorLiveUpdatedSectionsForUser` background thread → **unhandled exception** that can **kill the entire Jellyfin process** (observed on 2.5.11.0 / JF 10.11.11 when plugin `Enabled=true` with empty sections)

## Fix

- Null-coalesce `SectionSettings` to `Array.Empty<SectionSettings>()`
- `MaxOrderIndex = groupedOrderedSections.Select(x => x.Key).DefaultIfEmpty(0).Max()`

Empty config now caches a valid empty/zero-max structure instead of crashing.

## Test plan

- [ ] Fresh plugin config, `SectionSettings = []`, Modular Home enabled for a user → home loads without 500 on `/HomeScreen/Sections`
- [ ] Plugin `Enabled=true` with empty sections → server stays up after WebSocket/home load (no FTL unhandled exception)
- [ ] With non-empty `SectionSettings` and configured modular sections → behavior unchanged, sections still render
- [ ] `MaxOrderIndex` sensible when sections exist (same as previous Max of order keys)

Could not full-build here (environment is .NET 8 SDK; project targets .NET 9). Change is a one-liner guard; happy to adjust if you already have a preferred fix on a private branch.
