### PR TITLE
Cache transformation IDs per file instead of generating fresh ones

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/Services/StartupService.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Services/StartupService.cs
@@ -32,6 +32,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.Services
         private readonly IApplicationPaths m_applicationPaths;
         private readonly ILogger<HomeScreenSectionsPlugin> m_logger;
 
+        private Dictionary<string, Guid> m_registeredTransforms = new Dictionary<string, Guid>();
+
         public StartupService(IServerApplicationHost serverApplicationHost, IApplicationPaths applicationPaths, ILogger<HomeScreenSectionsPlugin> logger)
         {
             m_serverApplicationHost = serverApplicationHost;
@@ -64,7 +66,8 @@ namespace Jellyfin.Plugin.HomeScreenSections.Services
                     string fileName = Path.GetFileName(jsChunk);
                     Regex r = new Regex(@"([^.]+)\.([^.]+)\.chunk.js");
                     
-                    Guid guid = Guid.NewGuid();
+                    Guid guid = m_registeredTransforms.GetValueOrDefault(jsChunk, Guid.NewGuid());
+                    m_registeredTransforms[jsChunk] = guid;
                     m_logger.LogInformation($"Found loadSections in `{fileName}` registering transformation for it with ID '{guid}'");
                     
                     JObject payload = new JObject();


### PR DESCRIPTION
Closes #240.

Dug into this a bit before touching anything. StartupService hands out a brand new Guid.NewGuid() every time it runs, for every js chunk file it finds, then registers that with File Transformation. Turns out File Transformation's own storage dedupes by ID just fine, it's that main never gives it the same ID twice that breaks that. If the startup task fires more than once in the same server run, you get multiple registrations for the same file, and all of them stick around and all run.

I also poked at whether this could really pile up across restarts like the issue describes. Doesn't look like it can. File Transformation stores everything in memory and wipes it on restart, so there's nothing left from the old process to stack on top of. What's actually happening is duplicate registrations within one boot, which still lines up with seeing 6 sections instead of 2.

Good news, this is already fixed, just not here. v12 has the exact fix, a small dictionary that remembers the ID it already handed out for a file so it reuses that instead of generating a new one. Pulled just that part over to main and left out the library manager stuff bundled into the same v12 commit since that's a separate feature.

Build's clean, same warnings as main, nothing new. Also put together a tiny standalone repro comparing old vs new side by side. Happy to share it if useful, didn't include it in the PR since there's no test project here to add it to.