### PR TITLE
Fix scroll listener leak on the home screen

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/Controllers/loadSections.js
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Controllers/loadSections.js
@@ -416,7 +416,11 @@
                 userSettings: userSettings
             };
             
-            window.addEventListener('scroll', function () {
+            if (window.HssScrollHandler) {
+                window.removeEventListener('scroll', window.HssScrollHandler);
+            }
+
+            window.HssScrollHandler = function () {
                 var scrollPosition = window.scrollY + window.innerHeight;
                 var windowHeight = getDocHeight();
                 
@@ -460,7 +464,9 @@
                         D.body.clientHeight, D.documentElement.clientHeight
                     );
                 }
-            });
+            };
+
+            window.addEventListener('scroll', window.HssScrollHandler);
         }
         
         var getSectionsData = {


### PR DESCRIPTION
Closes #242.

You already root caused this one in the issue, so I just went with the fix you sketched out. Every time someone lands back on the home screen this file was attaching a fresh anonymous scroll listener with nothing removing the old ones. Enough visits in one tab and you've got a pile of listeners all firing on every scroll, which lines up with the slowdown you described.

Named the handler and stuck it on window, removing any old one before attaching a new one, so a repeat visit swaps the listener out instead of stacking another on top. Didn't touch anything inside the handler itself, just moved it from an anonymous function into a named one.

One thing worth mentioning on the testing side. This file has {{...}} placeholders the C# side fills in before it ever reaches a browser, so running it straight through node just errors out on those, even completely unmodified. Swapped in the same values TransformationPatches.cs actually substitutes at runtime and it parses clean both before and after this change. dotnet build is still clean too, same 12 warnings as main, nothing new.