### PR TITLE
Add Jellyfin 12.0 build target

### DIFF
--- a/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/Persons/PersonsSectionBase.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/HomeScreen/Sections/Persons/PersonsSectionBase.cs
@@ -1,8 +1,9 @@
-﻿using Jellyfin.Extensions;
+using Jellyfin.Extensions;
 using Jellyfin.Plugin.HomeScreenSections.Configuration;
 using Jellyfin.Plugin.HomeScreenSections.Helpers;
 using Jellyfin.Plugin.HomeScreenSections.Library;
 using Jellyfin.Plugin.HomeScreenSections.Model.Dto;
+using Jellyfin.Plugin.HomeScreenSections.JellyfinVersionSpecific;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
@@ -94,7 +95,7 @@ namespace Jellyfin.Plugin.HomeScreenSections.HomeScreen.Sections.Persons
             User? user = m_userManager.GetUserById(userId ?? Guid.Empty);
             // Want to use the user data at some point to actually weight the people chosen based on watch history, similar to how Genres are picked.
             // For now this is fine to get something in.
-            List<Person> people = m_libraryManager.GetPeopleItems(new InternalPeopleQuery(PersonTypes, Array.Empty<string>())).ToList();
+            List<Person> people = m_libraryManager.GetPeopleItemsVersionSpecific(new InternalPeopleQuery(PersonTypes, Array.Empty<string>()));
 
             people.Shuffle();
 

--- a/src/Jellyfin.Plugin.HomeScreenSections/Jellyfin.Plugin.HomeScreenSections.csproj
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Jellyfin.Plugin.HomeScreenSections.csproj
@@ -1,13 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <JellyfinVersion>10.11.5</JellyfinVersion>
+        <JellyfinVersion Condition="'$(JellyfinVersion)' == ''">12.0.0</JellyfinVersion>
         <JellyfinNugetVersion Condition="!$(JellyfinVersion.StartsWith('10.11'))">$(JellyfinVersion)</JellyfinNugetVersion>
         <JellyfinNugetVersion Condition="$(JellyfinVersion.StartsWith('10.11'))">$(JellyfinVersion)</JellyfinNugetVersion>
         <JellyfinNugetVersion Condition="$(JellyfinVersion.StartsWith('10.11.1'))">10.11.0</JellyfinNugetVersion>
         <JellyfinNugetVersion Condition="$(JellyfinVersion.StartsWith('10.11.0'))">10.11.0</JellyfinNugetVersion>
+        <JellyfinNugetVersion Condition="$(JellyfinVersion.StartsWith('12.'))">12.0.0-rc5</JellyfinNugetVersion>
         <TargetFramework Condition="$(JellyfinVersion.StartsWith('10.11'))">net9.0</TargetFramework>
         <TargetFramework Condition="'$(JellyfinVersion)' == '10.10.7'">net8.0</TargetFramework>
+        <TargetFramework Condition="$(JellyfinVersion.StartsWith('12.'))">net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -15,13 +17,27 @@
         <RepositoryUrl>https://github.com/IAmParadox27/jellyfin-plugin-home-sections</RepositoryUrl>
         <RepositoryType>GitHub</RepositoryType>
     </PropertyGroup>
+
+    <PropertyGroup>
+        <!-- Harmony 2.4.0 throws PlatformNotSupportedException on CoreCLR 10.
+             2.4.2 ships a net10.0 target. Bump only for Jellyfin 12.x. -->
+        <HarmonyVersion>2.4.0</HarmonyVersion>
+        <HarmonyVersion Condition="$(JellyfinVersion.StartsWith('12.'))">2.4.2</HarmonyVersion>
+        <HarmonyTfm>net8.0</HarmonyTfm>
+        <HarmonyTfm Condition="$(JellyfinVersion.StartsWith('12.'))">net10.0</HarmonyTfm>
+    </PropertyGroup>
+
     
     <PropertyGroup>
         <GitBranch Condition="$([System.IO.File]::Exists('$(MsBuildThisFileDirectory)..\..\.git\HEAD'))">$([System.IO.File]::ReadAllText('$(MsBuildThisFileDirectory)..\..\.git\HEAD').Replace('ref: refs/heads/', '').Trim())</GitBranch>
     </PropertyGroup>
     <PropertyGroup Condition="$([System.IO.File]::Exists('$(MsBuildThisFileDirectory)..\..\.git'))">
         <GitHeadLocation>$([System.IO.File]::ReadAllText('$(MsBuildThisFileDirectory)..\..\.git').Replace('gitdir: ', '').Trim())</GitHeadLocation>
-        <GitBranch>$([System.IO.File]::ReadAllText('$(MsBuildThisFileDirectory)..\..\$(GitHeadLocation)\HEAD').Replace('ref: refs/heads/', '').Trim())</GitBranch>
+        <!-- gitdir: in a worktree's .git file is an ABSOLUTE path, so it must not be
+             appended to the project-relative prefix. Path.Combine returns the second
+             argument unchanged when it is already rooted, which keeps this correct for
+             both a normal clone (relative gitdir) and a linked worktree. -->
+        <GitBranch>$([System.IO.File]::ReadAllText($([System.IO.Path]::Combine('$(MsBuildThisFileDirectory)..\..', '$(GitHeadLocation)', 'HEAD'))).Replace('ref: refs/heads/', '').Trim())</GitBranch>
     </PropertyGroup>
     
     <ItemGroup>
@@ -29,7 +45,7 @@
       <PackageReference Include="Jellyfin.Model" Version="$(JellyfinNugetVersion)" />
       <PackageReference Include="Jellyfin.Controller" Version="$(JellyfinNugetVersion)" />
       <PackageReference Include="Jellyfin.Extensions" Version="$(JellyfinNugetVersion)" />
-      <PackageReference Include="Lib.Harmony" Version="2.4.0" GeneratePathProperty="true" />
+      <PackageReference Include="Lib.Harmony" Version="$(HarmonyVersion)" GeneratePathProperty="true" />
       <PackageReference Include="SkiaSharp" Version="3.116.1" />
     </ItemGroup>
     
@@ -73,7 +89,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <EmbeddedResource Include="$(PkgLib_Harmony)\lib\net8.0\0Harmony.dll" />
+      <EmbeddedResource Include="$(PkgLib_Harmony)\lib\$(HarmonyTfm)\0Harmony.dll" />
     </ItemGroup>
     <ItemGroup>
         <None Include="..\..\README.md" />
@@ -114,4 +130,11 @@
         <Exec Condition="$(JellyfinVersion.StartsWith('10.11'))"     Command="xcopy $(OutDir) &quot;C:\ProgramData\Jellyfin\Server_10_11\plugins\HomeScreenSections&quot; /y" />
         <Exec Condition="'$(JellyfinVersion)' == '10.10.7'"     Command="xcopy $(OutDir) &quot;C:\ProgramData\Jellyfin\Server_10_10_7\plugins\HomeScreenSections&quot; /y" />
     </Target>
+
+    <!-- Remove 12.0 Specific Code from non 12.x builds -->
+    <ItemGroup Condition="!$(JellyfinVersion.StartsWith('12.'))">
+        <None Include="JellyfinVersionSpecific/12.0/*.cs" />
+        <Compile Remove="JellyfinVersionSpecific/12.0/*.cs" />
+    </ItemGroup>
+
 </Project>

--- a/src/Jellyfin.Plugin.HomeScreenSections/JellyfinVersionSpecific/10.10.7/ExtensionsHelper.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/JellyfinVersionSpecific/10.10.7/ExtensionsHelper.cs
@@ -1,4 +1,4 @@
-﻿using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities;
 
 namespace Jellyfin.Plugin.HomeScreenSections.JellyfinVersionSpecific
 {
@@ -7,6 +7,14 @@ namespace Jellyfin.Plugin.HomeScreenSections.JellyfinVersionSpecific
         public static bool IsPlayedVersionSpecific(this BaseItem item, User user)
         {
             return item.IsPlayed(user);
+        }
+
+        /// <summary>
+        /// Passthrough: on this Jellyfin version GetPeopleItems already returns the people.
+        /// </summary>
+        public static List<Person> GetPeopleItemsVersionSpecific(this MediaBrowser.Controller.Library.ILibraryManager libraryManager, MediaBrowser.Controller.Entities.InternalPeopleQuery query)
+        {
+            return libraryManager.GetPeopleItems(query).ToList();
         }
     }
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/JellyfinVersionSpecific/10.11/ExtensionsHelper.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/JellyfinVersionSpecific/10.11/ExtensionsHelper.cs
@@ -1,4 +1,4 @@
-﻿using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities;
 
 namespace Jellyfin.Plugin.HomeScreenSections.JellyfinVersionSpecific
 {
@@ -7,6 +7,14 @@ namespace Jellyfin.Plugin.HomeScreenSections.JellyfinVersionSpecific
         public static bool IsPlayedVersionSpecific(this BaseItem item, User user)
         {
             return item.IsPlayed(user, null);
+        }
+
+        /// <summary>
+        /// Passthrough: on this Jellyfin version GetPeopleItems already returns the people.
+        /// </summary>
+        public static List<Person> GetPeopleItemsVersionSpecific(this MediaBrowser.Controller.Library.ILibraryManager libraryManager, MediaBrowser.Controller.Entities.InternalPeopleQuery query)
+        {
+            return libraryManager.GetPeopleItems(query).ToList();
         }
     }
 }

--- a/src/Jellyfin.Plugin.HomeScreenSections/JellyfinVersionSpecific/12.0/BecauseYouWatchedHelper.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/JellyfinVersionSpecific/12.0/BecauseYouWatchedHelper.cs
@@ -1,0 +1,19 @@
+﻿using Jellyfin.Plugin.HomeScreenSections.Model.Dto;
+using MediaBrowser.Controller.Dto;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using Microsoft.AspNetCore.Identity;
+
+namespace Jellyfin.Plugin.HomeScreenSections.JellyfinVersionSpecific
+{
+    public static class BecauseYouWatchedHelper
+    {
+        public static InternalItemsQuery ApplySimilarSettings(this InternalItemsQuery query, BaseItem item)
+        {
+            query.Genres = item.Genres;
+            query.Tags = item.Tags;
+
+            return query;
+        }
+    }
+}

--- a/src/Jellyfin.Plugin.HomeScreenSections/JellyfinVersionSpecific/12.0/CollectionManagerProxy.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/JellyfinVersionSpecific/12.0/CollectionManagerProxy.cs
@@ -1,0 +1,27 @@
+﻿using System.Reflection;
+using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Controller.Collections;
+using MediaBrowser.Controller.Entities.Movies;
+
+namespace Jellyfin.Plugin.HomeScreenSections.JellyfinVersionSpecific
+{
+    public class CollectionManagerProxy
+    {
+        private readonly ICollectionManager m_collectionManager;
+
+        public CollectionManagerProxy(ICollectionManager collectionManager)
+        {
+            m_collectionManager = collectionManager;
+        }
+
+        public IEnumerable<BoxSet> GetCollections(User user)
+        {
+            return m_collectionManager.GetType()
+                .GetMethod("GetCollections", BindingFlags.Instance | BindingFlags.NonPublic)?
+                .Invoke(m_collectionManager, new object?[]
+                {
+                    user
+                }) as IEnumerable<BoxSet> ?? Enumerable.Empty<BoxSet>();
+        }
+    }
+}

--- a/src/Jellyfin.Plugin.HomeScreenSections/JellyfinVersionSpecific/12.0/ExtensionsHelper.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/JellyfinVersionSpecific/12.0/ExtensionsHelper.cs
@@ -1,0 +1,24 @@
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Querying;
+
+namespace Jellyfin.Plugin.HomeScreenSections.JellyfinVersionSpecific
+{
+    public static class ExtensionsHelper
+    {
+        public static bool IsPlayedVersionSpecific(this BaseItem item, User user)
+        {
+            return item.IsPlayed(user, null);
+        }
+
+        /// <summary>
+        /// Jellyfin 12.0 changed ILibraryManager.GetPeopleItems from
+        /// IReadOnlyList&lt;Person&gt; to QueryResult&lt;BaseItem&gt;. Adapt it back so the
+        /// shared section code stays version agnostic.
+        /// </summary>
+        public static List<Person> GetPeopleItemsVersionSpecific(this ILibraryManager libraryManager, InternalPeopleQuery query)
+        {
+            return libraryManager.GetPeopleItems(query).Items.OfType<Person>().ToList();
+        }
+    }
+}

--- a/src/Jellyfin.Plugin.HomeScreenSections/JellyfinVersionSpecific/12.0/GlobalUsings.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/JellyfinVersionSpecific/12.0/GlobalUsings.cs
@@ -1,0 +1,3 @@
+﻿global using Jellyfin.Database.Implementations.Entities;
+global using Jellyfin.Database.Implementations.Enums;
+global using Jellyfin.Data.Enums;

--- a/src/Jellyfin.Plugin.HomeScreenSections/JellyfinVersionSpecific/12.0/StartupServiceHelper.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/JellyfinVersionSpecific/12.0/StartupServiceHelper.cs
@@ -1,0 +1,24 @@
+﻿using MediaBrowser.Model.Tasks;
+
+namespace Jellyfin.Plugin.HomeScreenSections.JellyfinVersionSpecific
+{
+    public static class StartupServiceHelper
+    {
+        public static IEnumerable<TaskTriggerInfo> GetStartupTrigger()
+        {
+            yield return new TaskTriggerInfo()
+            {
+                Type = TaskTriggerInfoType.StartupTrigger
+            };
+        }
+
+        public static IEnumerable<TaskTriggerInfo> GetDailyTrigger(TimeSpan timeOfDay)
+        {
+            yield return new TaskTriggerInfo()
+            {
+                Type = TaskTriggerInfoType.DailyTrigger,
+                TimeOfDayTicks = timeOfDay.Ticks
+            };
+        }
+    }
+}

--- a/src/Jellyfin.Plugin.HomeScreenSections/Services/HomeScreenSectionService.cs
+++ b/src/Jellyfin.Plugin.HomeScreenSections/Services/HomeScreenSectionService.cs
@@ -170,7 +170,11 @@ namespace Jellyfin.Plugin.HomeScreenSections.Services
                 userSectionsData = new UserSectionsData()
                 {
                     UserId = userId,
-                    MaxOrderIndex = groupedOrderedSections.Max(x => x.Key)
+                    // Max() throws InvalidOperationException("Sequence contains no elements")
+                    // when the user has no sections configured, which surfaces as a 500 from
+                    // GET /HomeScreen/Sections and stops the home screen rendering at all.
+                    // An unconfigured plugin should return no sections, not fail the request.
+                    MaxOrderIndex = groupedOrderedSections.Select(x => x.Key).DefaultIfEmpty(0).Max()
                 };
                 
                 m_dataCache.Cache.TryAdd(pageHash.Value, userSectionsData);


### PR DESCRIPTION
Adds a Jellyfin 12.0 build target and fixes two real bugs.

**12.0 target** - `<JellyfinVersion>` 12.x maps to NuGet `12.0.0-rc5`, `net10.0`, and a
`JellyfinVersionSpecific/12.0/` shim. 10.10.7 and 10.11 still build.

**`ILibraryManager.GetPeopleItems` changed return type** in 12.0, from `IReadOnlyList<Person>` to
`QueryResult<BaseItem>`. Handled with a `GetPeopleItemsVersionSpecific` extension in each
version-specific `ExtensionsHelper`, so the shared section code stays version agnostic.

**Crash when no sections are configured.** `CacheSectionsForUser` called `.Max()` on an empty
grouping, throwing `InvalidOperationException: Sequence contains no elements`. That surfaced as a
500 from `GET /HomeScreen/Sections` and stopped the home screen rendering entirely for any user who
had not yet picked sections. Now uses `DefaultIfEmpty(0).Max()` so an unconfigured plugin returns
no sections instead of failing the request.

**Build fix:** the csproj reads `.git/HEAD` for the branch name, but in a linked worktree `.git` is
a *file* whose `gitdir:` is an absolute path - it was being appended to a project-relative prefix,
so the project only built from a normal clone. Now uses `[System.IO.Path]::Combine`, which returns a
rooted second argument unchanged and works for both layouts.

Also bumps Lib.Harmony to 2.4.2 for the 12.x target (2.4.0 rejects CoreCLR 10).
